### PR TITLE
[Miller] #1 20220302 BOJ_11724 풀이 제출

### DIFF
--- a/src/밀러/BOJ_11724.py
+++ b/src/밀러/BOJ_11724.py
@@ -1,0 +1,43 @@
+import collections
+from typing import List, Dict
+
+
+def solution(n: int, edges: List[List[int]]):
+
+    graph: Dict[int, List] = collections.defaultdict(list)
+    visited: List[bool] = [False for _ in range(n)]
+
+    for edge in edges:
+        graph[edge[0]].append(edge[1])
+        graph[edge[1]].append(edge[0])
+
+    stack = []
+    answer: int = 0
+
+    for vertex in range(1, n + 1):
+        if visited[vertex - 1]:
+            continue
+
+        answer += 1
+        stack.append(vertex)
+        visited[vertex - 1] = True
+
+        while stack:
+            now: int = stack.pop()
+
+            for dest in graph[now]:
+                if not visited[dest - 1]:
+                    stack.append(dest)
+                    visited[dest - 1] = True
+
+    return answer
+
+
+if __name__ == "__main__":
+    n, m = map(int, input().split())
+    edges: List[List[int]] = []
+
+    for _ in range(m):
+        edges.append(list(map(int, input().split())))
+
+    print(solution(n, edges))


### PR DESCRIPTION
안녕하세요, #1 문제를 업로드한 Miller 입니다 😀

### 접근방법

산토리가 푼 방식과 비슷하게, DFS 를 이용해 connected components 의 개수를 파악하는 방식으로 풀이했습니다. 

```python
    for vertex in range(1, n + 1):
        if visited[vertex - 1]:
            continue

        answer += 1
        stack.append(vertex)
        visited[vertex - 1] = True

        while stack:
            now: int = stack.pop()

            for dest in graph[now]:
                if not visited[dest - 1]:
                    stack.append(dest)
                    visited[dest - 1] = True
```

`stack` 은 방문 예정인 `vertex` 가 대기하는 스택이고, `visited` 는 방문 도장을 찍는 배열입니다.

각 원소를 순회하면서 방문하지 않은 `vertex` 인 경우 `stack` 에 추가합니다.
`while` 문 안에서 `stack` 의 원소가 없을 때까지 `vertex` 를 추출해,
`graph` 에서 해당 `vertex` 에서 출발하고 목적지인 `dest` 를 순회합니다.

순회하면서 이미 방문한 `dest` 인 경우 건너뛰고,
방문하지 않은 `dest` 만 `stack` 에 추가하고 `visitied` 배열에 방문 도장을 찍습니다.

### 참고사항

백준에서 문제를 많이 안풀어봤는데, 백준에서 Python3 로 실행하면 채점이 굉장히 느리고 시간 초과가 떴습니다.
그런데 PyPy3 로 실행하니까 깔끔하게 맞았다고 뜨네요..