### PR TITLE
[산토리] BOJ(15787): 기차가 어둠을 헤치고 은하수를 - 문제풀이

### DIFF
--- a/src/산토리/기차가 어둠을 헤치고 은하수를.py
+++ b/src/산토리/기차가 어둠을 헤치고 은하수를.py
@@ -1,0 +1,68 @@
+import sys
+# 1번 명령: x번째 좌석에 사람을 태워라 -> index 활용 시 O(1)
+# 2번 명령: x번째 좌석의 사람은 하차한다 -> hashMap 활용 시 O(1)
+# 3번 명령: 한칸씩 밀려난다 -> O(X)
+# 4번 명령: 한칸씩 앞으로 간다 -> O(X) 
+
+# 각 열차의 탑승상태를 set으로 관리한다 -> 중복된 상태는 통과할 수 없다.
+
+input = sys.stdin.readline
+
+N, M = list(map(int, input().split()))
+MAX_POS = 20
+trains = dict()
+
+for i in range(1, N+1):
+    trains[i] = dict()
+
+for _ in range(M):
+    cmd = list(map(int, input().split()))
+    if len(cmd) == 3:
+        mode, idx, pos = cmd
+        # idx -= 1
+        # pos -= 1
+        if mode == 1:
+            if trains[idx].get(pos) is None:
+                trains[idx][pos] = True
+        else:
+            if trains[idx].get(pos) is not None:
+                trains[idx].pop(pos)
+    else:
+        mode, idx = cmd
+        # idx -= 1
+        train = trains[idx]
+        if not train:
+            continue
+        temp = False
+        if mode == 3:
+            for p in range(1, MAX_POS+1):
+                if train.get(p) is not None:
+                    if not temp:
+                        train. pop(p)
+                    temp = True
+                else:
+                    if temp:
+                        train[p] = True
+                        temp = False
+        else:
+            temp = False
+            for p in range(MAX_POS, 0, -1):
+                if train.get(p) is not None:
+                    if not temp:
+                        train.pop(p)
+                    temp = True
+                else:
+                    if temp:
+                        train[p] = True
+                        temp = False
+
+
+print(trains)
+result = set()
+
+for train in trains.values():
+    
+    # print(tuple(train))
+    result.add(tuple(sorted(train)))
+
+print(len(result))


### PR DESCRIPTION
안녕하세요. 산토리입니다.
문제 풀이 업로드합니다.

## 접근 과정
특별한 알고리즘보다는 단순 구현이라고 생각하여 각 좌석을 dictionary로 만들어 풀었습니다. 최대 요청이 10만개이고 제일 오래 걸리는 연산인 shift할 때도 좌석의 개수가 20번밖에 안걸려서 시간초과는 나지 않을 것이라고 생각했습니다. 

좌석에 승차하거나 내릴 때는 그냥 key값으로 조회하여 없으면 태우고, 있으면 삭제하는 방식을 택했습니다. 한 칸씩 밀거나 당길 때는 for문을 돌면서 한 칸씩 옮겨주었습니다.

## 시간 복잡도
각 기차의 좌석을 만들어주는 작업: O(n*x), n: 기차의 개수, x: 좌석의 개수
요청을 처리하는 데 걸리는 시간: O(m*x), m: 요청의 개수, x: 좌석의 개수

## 삽질 과정
계속 맞왜틀을 반복했는데... 마지막에 set()을 통해서 탑승 상태의 중복을 제거하고 답을 출력하는 부분이 있었는데, 좌석에 해당하는 dictionary의 key값이 정렬이 되어있지 않기 때문에 중복을 걸러낼 때 잘 걸러지지 않는다는 걸 다른 블로그 풀이를 참고하다 알게 됐습니다.. 사소하지만 찾기 어려운 실수였어서 깨달음을 얻어갑니다..

## 추가로 공부해볼 점
이 문제를 비트마스킹으로도 풀 수 있다고 하는데 비트마스킹에 대해서 공부해보면 좋을 것 같습니다.