### PR TITLE
[산토리] BOJ(2003): 수들의 합 2 - 문제풀이

### DIFF
--- a/src/산토리/기차가 어둠을 헤치고 은하수를.py
+++ b/src/산토리/기차가 어둠을 헤치고 은하수를.py
@@ -19,8 +19,6 @@ for _ in range(M):
     cmd = list(map(int, input().split()))
     if len(cmd) == 3:
         mode, idx, pos = cmd
-        # idx -= 1
-        # pos -= 1
         if mode == 1:
             if trains[idx].get(pos) is None:
                 trains[idx][pos] = True
@@ -29,7 +27,6 @@ for _ in range(M):
                 trains[idx].pop(pos)
     else:
         mode, idx = cmd
-        # idx -= 1
         train = trains[idx]
         if not train:
             continue
@@ -57,12 +54,10 @@ for _ in range(M):
                         temp = False
 
 
-print(trains)
 result = set()
 
 for train in trains.values():
     
-    # print(tuple(train))
     result.add(tuple(sorted(train)))
 
 print(len(result))

--- a/src/산토리/수들의 합 2(수정).py
+++ b/src/산토리/수들의 합 2(수정).py
@@ -1,0 +1,24 @@
+# 결국은 left, right 둘 다 N번만 움직여야 된다.
+# left는 0~N까지 반복하는 와중에 right를 최대한 움직여보고 M보다 커지면 left를 줄여나가는 방법으로 간다.
+
+N, M = list(map(int, input().split()))
+
+nums = list(map(int, input().split()))
+
+answer = 0
+
+result = 0
+right = 0
+
+for left in range(N):
+    while result < M and right <= N-1:
+        result += nums[right]
+        right += 1
+    
+    if result == M:
+        answer += 1
+
+    # left 한 칸 이동
+    result -= nums[left]
+
+print(answer)

--- a/src/산토리/수들의 합 2.py
+++ b/src/산토리/수들의 합 2.py
@@ -1,0 +1,44 @@
+# 인덱스 0을 가리키는 포인터 두개를 만든다.
+# 합이 M보다 작으면 오른쪽 포인터를 하나 늘려 두 포인터가 가리키는 합을 구한다.
+# 여전히 작으면 오른쪽 포인터를 하나 늘려 합에 새 숫자를 더한다.
+
+# 합이 M보다 크면 전부 양수이기 때문에 더 더해도 소용이 없다. 왼쪽 포인터를 하나 늘려 다음 구간을 탐색한다.
+# 오른쪽 포인터도 왼쪽 포인터 위치로 옮긴다. 
+
+# 합이 M이면 답에 기록하고 왼쪽 포인터를 한 칸 오른쪽으로 옮긴다.  
+
+# left가 맨끝에 도달할 때까지 반복한다.
+
+N, M = list(map(int, input().split()))
+
+nums = list(map(int, input().split()))
+
+answer = 0
+
+left, right = 0, 0 
+result = 0
+
+while left <= N-1:
+    result += nums[right]
+    # print(result, left, right, answer)
+
+    if result == M:
+        answer += 1
+        left += 1
+        right = left
+        result = 0
+
+    elif result < M:
+        if right < N-1:
+            right += 1
+        else:
+            left += 1
+            right = left
+            result = 0
+
+    else:
+        left += 1
+        right = left
+        result = 0
+
+print(answer)

--- a/src/산토리/예산.py
+++ b/src/산토리/예산.py
@@ -9,12 +9,11 @@ def get_answer():
         return max_req
 
     avg = total // N
-    print("avg:",avg)
     if min_req >= avg:
         return avg
 
     limit = avg
-    while True:
+    for _ in range(2):
         remain = total
         cnt = 0
         for r in req:


### PR DESCRIPTION
안녕하세요. 산토리입니다.
문제 풀이 업로드합니다.

## 접근 과정

수열의 항 개수가 최대 10000개이고, 시간 제한이 0.5초인 점을 감안하여 O(nlogn)이내로 통과해야되겠다고 생각했습니다.
순서를 지켜야하기 때문에 정렬 등을 활용할 수 없고, 한 항을 고정하고 더하는 일반적인 브루트포스를 활용하면 O(n^2)이 됩니다.
그래서 이를 개선하는 대표적인 알고리즘인 투 포인터 방식으로 접근했습니다.

left, right의 두 포인터를 놓고 left를 고정한 상태에서 right를 전진시키다가 주어진 목표값보다 커지면 left를 한칸 이동하고 다시 비교해보는
식으로 각 포인터가 한 번만 순회해도 모든 경우의 수를 탐색할 수 있도록 하였습니다.

## 삽질 과정

처음에 투 포인터로 접근했는데 시간 초과가 발생했습니다. 틀린 코드도 같이 첨부하였는데, 투 포인터로 접근은 했지만 탐색 결과를 활용하지 않고 M을 초과하면 다시 left, right 포인터를 같은 자리에서 시작했던 것이 패착이었던 것 같습니다. 이렇게 되면 left는 한 번만 탐색하지만 right는 계속 갔던 곳을 돌아오기 때문입니다. 

## 시간 복잡도

각 포인터가 수열을 한번씩만 탐색하므로 O(n)
