### PR TITLE
[Miller] BOJ(2003): 수들의 합 2 - 문제풀이

### DIFF
--- a/src/밀러/BOJ_2003.py
+++ b/src/밀러/BOJ_2003.py
@@ -1,0 +1,42 @@
+from typing import List
+
+
+def solution(N: int, M: int, numbers: List[int]):
+
+    count: int = 0
+
+    for ind in range(N):
+        if is_target(ind, ind):
+            count += 1
+
+        if is_target(ind, ind + 1):
+            count += 1
+
+    return count
+
+
+def is_target(left: int, right: int):
+    total: int = sum(numbers[left: right + 1])
+
+    if left >= 0 and right < N and total == M:
+        return True
+
+    while left > 0 and right < N - 1 and \
+            numbers[left - 1] + numbers[right + 1] + total <= M:
+
+        left -= 1
+        right += 1
+        total += numbers[left] + numbers[right]
+
+        if total == M:
+            return True
+
+    return False
+
+
+if __name__ == "__main__":
+    N, M = list(map(int, input().split()))
+
+    numbers: List[int] = list(map(int, input().split()))
+
+    print(solution(N, M, numbers))


### PR DESCRIPTION
안녕하세요 BOJ 2003 풀이를 들고 온 Miller 입니다 😀😀

### 접근과정

투 포인터로 풀기로 마음을 먹었는데, 다른 분들과 달리 원소를 순회하면서
각 인덱스마다 짝수/홀수로 윈도우를 만들고 윈도우를 좌우로 넓혀가면서 문제를 풀이했습니다.

### 시간 복잡도

제 생각엔 O(n^2) 인데 브루트포스로 원소를 순회하는 경우보다 검사하는 횟수가 적어 풀리지 않았을까 생각합니다.

### 삽질 과정

처음에 모든 원소를 정렬해놓고 풀었는데, 알고보니 정렬하면 안되는 문제더라구요.
다시 풀면서 58% 에서 틀리는 결과가 나와서, 엣지 케이스가 나기 쉬운 경우를 대입해 해결했습니다.