### PR TITLE
[Jay] BOJ(2003): 수들의 합 2 - 문제풀이

### DIFF
--- a/src/제이/week2/BOJ_2003.java
+++ b/src/제이/week2/BOJ_2003.java
@@ -1,0 +1,70 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class BOJ_2003{
+
+    private int n;
+    private int m;
+    private int[] numbers;
+
+    private void solve() throws IOException {
+        readInput();
+
+        int count = 0;
+
+        for (int p1 = 0; p1 < numbers.length; p1++) {
+            int sum = 0;
+            int num1 = numbers[p1];
+
+            // 첫 포인터의 숫자가 합보다 크면 더 탐색할 필요 없음
+            if (num1 > m) continue;
+
+            // 첫 포인터의 숫자가 합과 같으면 count 하고, 더 탐색할 필요 없음
+            if (num1 == m) {
+                count++;
+                continue;
+            }
+
+            sum += num1;
+
+            for (int p2 = p1 + 1; p2 < numbers.length; p2++) {
+                int num2 = numbers[p2];
+                sum += num2;
+                if (sum == m) {
+                    count++;
+                    break;
+                }
+
+                // 만약 끝까지 모두 더했는데도 합보다 작으면, 이 숫자들로는 m 만큼의 합을 만들 수 없으므로 바로 종료
+                if (p2 == numbers.length-1 && sum < m) {
+                    System.out.println(count);
+                    return;
+                }
+            }
+        }
+
+        System.out.println(count);
+    }
+
+    private void readInput() throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        String[] split = br.readLine().split(" ");
+        n = Integer.parseInt(split[0]);
+        m = Integer.parseInt(split[1]);
+
+        numbers = new int[n];
+
+        split = br.readLine().split(" ");
+
+        for (int i = 0; i < split.length; i++) {
+            numbers[i] = Integer.parseInt(split[i]);
+        }
+    }
+
+    public static void main(String[] args) throws IOException {
+        BOJ_2003 q = new BOJ_2003();
+        q.solve();
+    }
+}


### PR DESCRIPTION
안녕하세요 Jay 입니다.
이번문제는 생각보다 간단하게 풀렸습니다..!

# 시간복잡도

제 풀이의 시간복잡도는 `O(nLog(n))` 입니다.

지난주에 산토리가 1초에 약 1억번의 연산할 수 있다고 가정하고 시간복잡도를 계산하면 된다고 하셨는데,
이번 문제는 제한 시간이 0.5초이기 때문에 이번 문제에서는 약 `50,000,000`번의 연산내에 풀이해야합니다.

이번 문제에서 n의 최대값은 10,000 이고 `nLog(n)`의 시간복잡도임을 고려하면, 
약 `40,000`번의 연산을 한다고 생각할 수 있습니다.

그래서 시간내에 풀이할 수 있을것이라 생각했습니다!

\+ 다 풀고 보니 땃쥐는 누적합으로 풀이하셨던데, 누적합이 시간복잡도를 줄일 수 있는 좋은 풀이방법인 것 같다는 생각이드네요..!

# 접근 과정

기본 풀이는 두 포인터 방식으로 풀었습니다.
그리고 탈출 조건을 최대한 많이 붙여서 반복문을 최대한 빨리 탈출할 수 있도록 신경썼습니다.
(그런데 그렇게 큰 시간 차이는 나지 않더라구요!)

```java
for (int p1 = 0; p1 < numbers.length; p1++) {
    int sum = 0;
    int num1 = numbers[p1];

    // 첫 포인터의 숫자가 합보다 크면 더 탐색할 필요 없음
    if (num1 > m) continue;

    // 첫 포인터의 숫자가 합과 같으면 count 하고, 더 탐색할 필요 없음
    if (num1 == m) {
        count++;
        continue;
    }

    sum += num1;

    for (int p2 = p1 + 1; p2 < numbers.length; p2++) {
        int num2 = numbers[p2];
        sum += num2;
        if (sum == m) {
            count++;
            break;
        }

        // 만약 끝까지 모두 더했는데도 합보다 작으면, 이 숫자들로는 m 만큼의 합을 만들 수 없으므로 바로 종료
        if (p2 == numbers.length-1 && sum < m) {
            System.out.println(count);
            return;
        }
    }
}
```

# 삽질 과정

삽질 과정이 없었습니다!👍