### PR TITLE
[zzangmin] BOJ(1463): 1로 만들기

### DIFF
--- a/src/짱민/1463.py
+++ b/src/짱민/1463.py
@@ -1,0 +1,36 @@
+import sys;input=sys.stdin.readline
+from collections import deque
+N=int(input())
+
+dp = [sys.maxsize] * (N+1)
+
+
+def dfs():
+    Q=deque()
+    Q.append(N)
+    while Q:
+        pointer=Q.popleft()
+
+        if pointer%3 == 0 and checkRange(pointer//3) :
+            if dp[pointer//3] >= dp[pointer]+1:
+                dp[pointer//3] = dp[pointer] + 1
+                Q.append(pointer//3)
+
+        if pointer%2 == 0 and checkRange(pointer//2):
+            if dp[pointer//2] >= dp[pointer] + 1:
+                dp[pointer//2] = dp[pointer] + 1
+                Q.append(pointer//2)
+
+        if checkRange(pointer-1):
+            if dp[pointer-1] >= dp[pointer] + 1:
+                dp[pointer-1] = dp[pointer] + 1
+                Q.append(pointer-1)
+    
+def checkRange(pointer):
+    if 1 <= pointer < N:
+        return True
+    return False
+
+dp[N]=0
+dfs()
+print(dp[1])


### PR DESCRIPTION
## 안녕하세요
DP를 안쓰면 못푸는 문제네요~~

## 시간복잡도
시간복잡도 계산은 사실 잘 못하지만,,, 파이썬3 기준으로 1.5초고 N의 범위가 백만이니 O(NlogN) 에서 O(N) 정도의 방법을 쓰면 될 것 같네요. 제 방법은 야매식 NlogN 인것 같습니다


## 접근 과정
전에 풀어봤던 문제라 DP인건 알고 있었으나 풀고나서 전의 제 코드를 보니 거의 다르게 풀었더군요
배열하나를 선언해놓고 dfs로 최단거리를 구하는 것처럼 풀었습니다.
파이썬은 인터프리터 언어라서 아마 인덱싱 과정에서 pointer%3 이나 pointer//3 같은 코드가 반복돼서 연산량이 좀 늘었을 수도 있습니다. 자바는 상관 없을 것 같은데 이부분 최적화 하면 소요시간이 더 줄 것같습니다.

## 삽질 과정
3가지 경우를 모두 생각해서 각각 if문으로 분기를 나눴어야 하는데 무의식적으로 if -elif - elif로 구현해서 1차 난관
pointer//3 같은 코드를 박아서 넣다보니 오타가 발생해서로 2차 난관

결론 : 문제풀이에도 클린 코드가 필요하다....
