### PR TITLE
[Miller] BOJ(1463): 1로 만들기 - 문제풀이

### DIFF
--- a/src/밀러/BOJ_1463.py
+++ b/src/밀러/BOJ_1463.py
@@ -1,0 +1,47 @@
+# N: int = int(input())
+# dp = [0 for _ in range(N + 1)]
+# dp[1] = 0
+#
+#
+# def solution(n: int) -> int:
+#
+#     if n == 1 or dp[n]:
+#         return dp[n]
+#
+#     if n % 3 == 0:
+#         dp[n] = solution(n // 3) + 1
+#         return dp[n]
+#
+#     if n % 2 == 0:
+#         dp[n] = min(solution(n // 2), solution(n - 1)) + 1
+#         return dp[n]
+#
+#     dp[n] = solution(n - 1) + 1
+#     return dp[n]
+#
+#
+# print(solution(N))
+
+import sys
+from typing import List
+
+
+def solution(n: int) -> int:
+    dp: List[int] = [sys.maxsize for _ in range(N + 1)]
+    dp[1] = 0
+
+    for i in range(2, n + 1):
+        dp[i] = dp[i - 1] + 1
+
+        if i % 2 == 0 and dp[i] > dp[i // 2] + 1:
+            dp[i] = dp[i // 2] + 1
+
+        if i % 3 == 0 and dp[i] > dp[i // 3] + 1:
+            dp[i] = dp[i // 3] + 1
+
+    return dp[n]
+
+
+if __name__ == "__main__":
+    N: int = int(input())
+    print(solution(N))


### PR DESCRIPTION
안녕하세요 BOJ 1463 번 문제풀이를 들고 온 Miller 입니다.

### 접근 과정/삽질 과정

일단 제가 이 문제를 고른 이유는 DP(동적계획법) 을 한 번도 풀어본 적이 없었기 때문입니다.
문제 출제를 위해 알고리즘 분류를 이미 알고 고른 문제여서, 상향식/하향식 접근법 중 하향식으로 접근하고자 했습니다.

```python
dp = [0 for _ in range(N + 1)]
dp[1] = 0

def solution(n: int) -> int:

    if n == 1 or dp[n]:
        return dp[n]

    if n % 3 == 0:
        dp[n] = solution(n // 3) + 1
        return dp[n]

    if n % 2 == 0:
        dp[n] = min(solution(n // 2), solution(n - 1)) + 1
        return dp[n]

    dp[n] = solution(n - 1) + 1
    return dp[n]
```

먼저 3으로 나눌 수 있는 경우 나누고, 그렇지 않은 경우 2로 나누기와 1 빼기 중 작은 값을 반환하는 값을 택하려고 했습니다.
근데 이 방법으로 채점을 해보니 60% 대에서 '틀렸습니다' 가 뜨더라구요...?

이해가 안가서 고쳐보다가 도저히 로지컬 에러를 못찾을 것 같아, 결국 상향식 접근법으로 풀었습니다.

```python
def solution(n: int) -> int:
    dp: List[int] = [sys.maxsize for _ in range(N + 1)]
    dp[1] = 0

    for i in range(2, n + 1):
        dp[i] = dp[i - 1] + 1

        if i % 2 == 0 and dp[i] > dp[i // 2] + 1:
            dp[i] = dp[i // 2] + 1

        if i % 3 == 0 and dp[i] > dp[i // 3] + 1:
            dp[i] = dp[i // 3] + 1

    return dp[n]
```

접근 방법은 작은 수부터 큰 수로 접근하면서 계산을 하며, `dp[n]` 에 대해 `dp[n-1] + 1` 을 기본 값으로 가집니다.
그리고 `n` 이 2로 나뉘면 `dp[n]` 과 비교하고, 3으로 나뉘면 또 `dp[n]` 과 비교합니다.
이 문제를 풀기 직전에 다익스트라 알고리즘 문제를 풀었는데, 비슷한 접근이지 않나 싶네요.

### 시간 복잡도

DP 문제를 처음 풀어봐서 시간 제한이 빡센 문제에서 상향식으로 모든 N 에 대해 접근 시 TLE 가 발생하는거 아닌가 싶었는데,
시간 복잡도도 O(N) 이고 연산횟수가 최대 10^6 * 4 이면 안전하게 풀릴 것이라고 생각했습니다.


