### PR TITLE
BOJ_1463 풀이

### DIFF
--- a/src/땃쥐/BOJ_1463.java
+++ b/src/땃쥐/BOJ_1463.java
@@ -1,0 +1,34 @@
+package 땃쥐;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class BOJ_1463 {
+
+    private static int[] dp;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int N = Integer.parseInt(br.readLine());
+        br.close();
+        dp = new int[N+1];
+        System.out.print(dp(N));
+    }
+
+    private static int dp(int k) {
+        if (k==0||k==1||dp[k] != 0) return dp[k];
+        else {
+            if (k%6 == 0) {
+                dp[k] = Math.min(Math.min(dp(k/3), dp(k/2)), dp(k-1)) + 1;
+            } else if (k%3 ==0) {
+                dp[k] = Math.min(dp(k/3),dp(k-1)) +1;
+            } else if (k%2 ==0) {
+                dp[k] = Math.min(dp(k/2),dp(k-1)) +1;
+            } else {
+                dp[k] = dp(k-1) + 1;
+            }
+        }
+        return dp[k];
+    }
+}


### PR DESCRIPTION
예전에 풀어보고 답을 찾아봤던 문제인데 그대로 이해가 안 가는 감이 많습니다.

---

## 시간복잡도

DP알고리즘에 의해 각 값들은 1회씩 계산되므로, O(N) 입니다.

---

## 접근과정
- 처음 접할 때 도저히 스스로 풀 자신이 없는 문제였습니다.
- DP가 한번 계산한 것들은 값을 저장한다는 알고리즘이긴한데 그것만으로는 이 문제를 푸는데 제 실전 경험이 부족해서 바로 와닿지 않았습니다.


---

## 삽질과정
그림을 그려보고 각  숫자 상황에서 2로 나누어 떨어질 때, 3으로 나누어 떨어질 때, 6으로 나누어질때, 그렇지 않을때 이렇게 케이스 분류를 하다가 머리를 엄청 싸맸습니다. 

---

## 풀이

```java
    private static int dp(int k) {
        if (k==0||k==1||dp[k] != 0) return dp[k];
        else {
            if (k%6 == 0) {
                dp[k] = Math.min(Math.min(dp(k/3), dp(k/2)), dp(k-1)) + 1;
            } else if (k%3 ==0) {
                dp[k] = Math.min(dp(k/3),dp(k-1)) +1;
            } else if (k%2 ==0) {
                dp[k] = Math.min(dp(k/2),dp(k-1)) +1;
            } else {
                dp[k] = dp(k-1) + 1;
            }
        }
        return dp[k];
    }
```
- 재귀를 활요합니다.
- 종료 조건1 :  k값이 0 또는 1인 경우, 또는 dp[k]가 0이 아닌 모든 경우(이미 계산된 경우) 기본값인을 그대로 반환합니다.

- 그렇지 않은 모든 경우에 대하여
6의 배수일 경우, 3으로 나눈 경우, 2로 나눈 경우 1로 나눈 경우의 dp값에 대하여 최솟값을 구한뒤 1을 더합니다.
3의 배수일 경우 3으로 나눈 경우, 1을 뺀 경우의 dp값에 대하여 최솟값을 구한뒤 1을 더합니다.
2의 배수일 경우 2로 나눈 경우, 1을 뺀 경우의 dp값에 대하여 최솟값을 구한 뒤 1을 더한뒤 저장합니다.
어느 쪽에도 속하지 않을 경우 1을 뺀 값의 dp값에 1을 더합니다.

---

## 소요시간

212ms