### PR TITLE
[산토리] 프로그래머스(42898): 등굣길 - 문제풀이

### DIFF
--- a/src/산토리/등굣길.py
+++ b/src/산토리/등굣길.py
@@ -1,0 +1,24 @@
+def solution(m, n, puddles):
+    answer = 0
+    
+    dp = [[1 for _ in range(m)] for _ in range(n)]
+    
+    
+    for r in range(n):
+        for c in range(m):
+            if [c+1, r+1] in puddles:
+                dp[r][c] = 0
+                continue
+            if r == 0:
+                dp[r][c] = dp[r][c-1]
+                continue
+            if c == 0:
+                dp[r][c] = dp[r-1][c]
+                continue
+            
+            dp[r][c] = (dp[r-1][c] + dp[r][c-1])%1000000007
+
+    answer = dp[n-1][m-1]
+
+
+    return answer


### PR DESCRIPTION
안녕하세요. 산토리입니다.
화요일 문제 풀이 업로드합니다~

## 🐢 접근 과정

각 칸에 최단거리로 이동하는 경우의 수를 dp 배열에 담아 풀이했습니다.
최단거리로 이동하는 경우의 수 문제 풀듯이, dp[r][c] = dp[r-1][c] + dp[r][c-1] 을 통해 경우의 수를 계산해나갑니다.
이 때, 물 웅덩이의 처리는 해당 칸의 경우의 수를 0으로 만드는 것입니다.
물 웅덩이를 지나갈 수 없기 때문에 도달할 수 있는 경우의 수가 0이기 때문입니다.
그렇게 처리하고 진행하여 맨 마지막 칸의 dp값을 반환하면 됩니다.

## 😡 삽질 과정
1. 처음에는 전체 경우의 수에서 웅덩이를 지나는 경우의 수를 빼려고 했는데, 웅덩이가 여러 개일 수 있기 때문에 모든 웅덩이를 고려해야 했다. 
2. 첫 행과 첫 열은 무조건 1일 거라 생각했는데, 웅덩이가 등장한 이후의 칸들은 최단거리 경로에서 제외되기 때문에 경우의 수를 0으로 생각한다.

## 🕖 시간 복잡도

MxN 격자를 모두 순회하므로 O(MN)입니다.
