### PR TITLE
[땃쥐] 프로그래머스 (42898) : 등굣길 - 문제풀이

### DIFF
--- a/src/땃쥐/Programmers_42898.java
+++ b/src/땃쥐/Programmers_42898.java
@@ -1,0 +1,30 @@
+package 땃쥐;
+
+public class Programmers_42898 {
+
+    public int solution(int m, int n, int[][] puddles) {
+
+        int[][] routeCounter = new int[n+1][m+1]; // 각 인덱스는 그 지점에 올 수 있는 가짓수로 취급
+
+        for (int[] puddle : puddles) { // 웅덩이는 일단 -1로 체킹
+            routeCounter[puddle[1]][puddle[0]] = -1;
+        }
+
+        routeCounter[1][0] = 1; // 1,1의 왼쪽값을 1로 가정
+
+        for (int i=1; i<=n; i++) {
+            for (int j=1; j<=m; j++) {
+                if (routeCounter[i][j] == -1) {
+                    routeCounter[i][j] = 0; // 웅덩이가 있는 곳에 올 수 있는 경우의 수는 0이다.
+                } else {
+                    routeCounter[i][j] = (routeCounter[i][j-1] + routeCounter[i-1][j])%1_000_000_007;
+                    // 위의 좌표에 도달할 수 있는 경우의 수 + 왼쪽의 좌표에 도달할 수 있는 경우의 수
+                }
+            }
+        }
+
+        int answer = routeCounter[n][m];
+        return answer;
+    }
+
+}


### PR DESCRIPTION
안녕하세요... 어려운 문제를 주셨군요...
풀리퀘 올립니다.

---

## 시간복잡도
m,n 이중 for문 돌면서 처리하므로 시간 복잡도는 O(mn)일 것으로 추정됩니다.

---

## 삽질

무작정 다 더해서 마지막 값만 나머지 처리를 했는데, 이 부분에서 효율성 테스트가 빨간불이 뜨더라구요.
그래서, 각 값을 합치는 과정에서부터 나머지 처리를 했습니다.

(a+b....+z)%m = (a%m + b%m+ ... + z%m)%m 인 것을 이용했는데 왜 이렇게 하면 효율성이 좋아지는지 아직 잘 모르겠습니다.



## 접근방법

![route](https://user-images.githubusercontent.com/88282356/158508926-d360e40e-66bd-4644-ae93-b17ba322395f.jpg)

```java
        int[][] routeCounter = new int[n+1][m+1]; // 각 인덱스는 그 지점에 올 수 있는 가짓수로 취급

        for (int[] puddle : puddles) { // 웅덩이는 일단 -1로 체킹
            routeCounter[puddle[1]][puddle[0]] = -1;
        }

        routeCounter[1][0] = 1; // 1,1의 왼쪽값을 1로 가정

        for (int i=1; i<=n; i++) {
            for (int j=1; j<=m; j++) {
                if (routeCounter[i][j] == -1) {
                    routeCounter[i][j] = 0; // 웅덩이가 있는 곳에 올 수 있는 경우의 수는 0이다.
                } else {
                    routeCounter[i][j] = (routeCounter[i][j-1] + routeCounter[i-1][j])%1_000_000_007;
                    // 위의 좌표에 도달할 수 있는 경우의 수 + 왼쪽의 좌표에 도달할 수 있는 경우의 수
                }
            }
        }
```
- 이차원 배열을 정의합니다.
- 최초에는 물웅덩이 좌표를 읽고 그 부분을 -1로 처리합니다.
- (1,1)의 왼쪽 값을 1로 초기화합니다.
- 이차원 배열의 각 인덱스를 탐색하면서(가로 m, 세로 n번), -1이 있을 경우 0으로 변경. 아닌 경우 위쪽 왼쪽 값을 합치는 식으로 처리합니다.
- 이차원 배열을 정의하고 각 인덱스의 위, 왼쪽의 값을 합쳐가는 식으로 처리했습니다.

---

## 결과
![image](https://user-images.githubusercontent.com/88282356/158508733-cdd8af55-1bf3-413e-9181-8e1ffe6cc9bf.png)

파란불 뜨네용 나이뜨