### PR TITLE
[산토리] BOJ(1780): 종이의 개수 - 문제풀이

### DIFF
--- a/src/산토리/종이의 개수.py
+++ b/src/산토리/종이의 개수.py
@@ -1,0 +1,52 @@
+# 스택에 직접 배열을 다 담지말고 for문을 탐색할 인덱스만 기록하자
+# 탐색하는 함수를 따로만들어서 답 여부를 확인한다
+
+N = int(input())
+
+board = []
+
+for _ in range(N):
+    board.append(list(map(int, input().split())))
+
+
+stack = []
+stack.append([0,0,N,N])
+
+answer = [0] * 3
+
+def check(r1, c1, r2, c2):
+    start = board[r1][c1]
+
+    if r1 == r2 and c1 == c2:
+        return True
+
+    for r in range(r1, r2):
+        for c in range(c1, c2):
+            if start != board[r][c]:
+                return False
+
+    return True
+
+def get_answer(stack):
+    while stack:
+        r1, c1, r2, c2 = stack.pop()
+
+        if check(r1, c1, r2, c2):
+            answer[board[r1][c1]+1] += 1
+
+        else:
+            unit = (r2-r1)//3
+
+            if unit == 1:
+                for i in range(r1, r2):
+                    for j in range(c1, c2):
+                        answer[board[i][j]+1] += 1
+                continue
+            
+            # print(unit)
+            for i in range(3):
+                for j in range(3):
+                    stack.append([r1+unit*i, c1+unit*j, r1+unit*(i+1), c1+unit*(j+1)])                         
+get_answer(stack)
+for ans in answer:
+    print(ans)


### PR DESCRIPTION
안녕하세요. 산토리입니다.
목요일 문제 풀이 업로드합니다~

## 🐢 접근 과정

주어진 종이를 탐색하다가 조건을 만족하지 않는 경우 작은 종이로 쪼개서 다시 탐색합니다. 재귀나 스택을 사용해 조건이 맞지 않을 때마다 연산을 추가해주는 식으로 접근해보려고 했습니다.

스택에 탐색할 범위를 저장해두었다가 하나씩 꺼내서 해당범위를 탐색하기 시작합니다.
처음에는 전체 범위를 넣고, 만족하지 않을 때마다 9조각으로 나눈 범위를 stack에 넣어줍니다

## 😡 삽질 과정
처음에 stack에 탐색할 board의 일부분을 모두 저장했더니 메모리 초과가 발생했습니다. 그래서 그냥 탐색할 범위만 기록해두고 원본 board의 index 접근을 통해 조사하는 것으로 개선했습니다.

추가로 size가 1칸인 경우는 무조건 조건을 만족하므로 stack에 담지않고 미리 반영하고 건너뜁니다.

##  🕖 시간 복잡도
최악의 경우는 전체가 크기 1짜리 종이로 찢어지는 경우일 것 같습니다.
그럴 때 결국 스택 계산을 1+9+81+... 번 하게 되는데 총 횟수는 (9^(k+1)-1)/8이 됩니다.
9^(k+1) = 3^k = N의 제곱 꼴이므로, O(N^2)인 것 같습니다.