### PR TITLE
[Miller] BOJ (1780) : 종이의 개수 - 문제 풀이

### DIFF
--- a/src/밀러/BOJ_1780.py
+++ b/src/밀러/BOJ_1780.py
@@ -1,0 +1,60 @@
+from typing import List
+
+
+def solution(arr: List[List[int]]) -> List[int]:
+    view: List[int] = []
+    for row in arr:
+        view.extend(row)
+
+    if list(set(view)) == [-1]:
+        return [1, 0, 0]
+    if list(set(view)) == [0]:
+        return [0, 1, 0]
+    if list(set(view)) == [1]:
+        return [0, 0, 1]
+
+    size: int = len(arr) // 3
+
+    nw: List[List[int]] = [arr[i][:size] for i in range(0, size)]
+    n: List[List[int]] = [arr[i][size: size * 2] for i in range(0, size)]
+    ne: List[List[int]] = [arr[i][size * 2:] for i in range(0, size)]
+
+    w: List[List[int]] = [arr[i][:size] for i in range(size, size * 2)]
+    c: List[List[int]] = [arr[i][size:size * 2] for i in range(size, size * 2)]
+    e: List[List[int]] = [arr[i][size * 2:] for i in range(size, size * 2)]
+
+    sw: List[List[int]] = [arr[i][:size] for i in range(size * 2, size * 3)]
+    s: List[List[int]] = [arr[i][size:size * 2] for i in range(size * 2, size * 3)]
+    se: List[List[int]] = [arr[i][size * 2:] for i in range(size * 2, size * 3)]
+
+    nw: List[int] = solution(nw)
+    n: List[int] = solution(n)
+    ne: List[int] = solution(ne)
+
+    w: List[int] = solution(w)
+    c: List[int] = solution(c)
+    e: List[int] = solution(e)
+
+    sw: List[int] = solution(sw)
+    s: List[int] = solution(s)
+    se: List[int] = solution(se)
+
+    result = [0, 0, 0]
+    for frac in [nw, n, ne, w, c, e, sw, s, se]:
+        result[0] += frac[0]
+        result[1] += frac[1]
+        result[2] += frac[2]
+
+    return result
+
+
+if __name__ == "__main__":
+    N: int = int(input())
+
+    arr: List[List[int]] = []
+    for _ in range(N):
+        arr.append(list(map(int, input().split())))
+
+    answer: List[int] = solution(arr)
+    for num in answer:
+        print(num)

--- a/src/밀러/BOJ_2630.py
+++ b/src/밀러/BOJ_2630.py
@@ -1,0 +1,41 @@
+from typing import List
+
+
+def divide(arr: List[List[int]], n: int) -> List[int]:
+    total: int = 0
+    for row in arr:
+        total += sum(row)
+
+    if total == 0:
+        return [1, 0]
+    if total == len(arr) ** 2:
+        return [0, 1]
+
+    nw: List[List[int]] = [arr[i][:n // 2] for i in range(n // 2)]
+    ne: List[List[int]] = [arr[i][n // 2:] for i in range(n // 2)]
+    sw: List[List[int]] = [arr[i][:n // 2] for i in range(n // 2, n)]
+    se: List[List[int]] = [arr[i][n // 2:] for i in range(n // 2, n)]
+
+    nw: List[int] = divide(nw, n // 2)
+    ne: List[int] = divide(ne, n // 2)
+    sw: List[int] = divide(sw, n // 2)
+    se: List[int] = divide(se, n // 2)
+
+    result = [0, 0]
+    for fraction in [nw, ne, sw, se]:
+        result[0] += fraction[0]
+        result[1] += fraction[1]
+    return result
+
+
+if __name__ == "__main__":
+    N: int = int(input())
+    arr: List[List[int]] = []
+
+    for _ in range(N):
+        arr.append(list(map(int, input().split())))
+
+    answer: List[int] = divide(arr, N)
+    print(answer[0])
+    print(answer[1])
+


### PR DESCRIPTION
안녕하세요, BOJ 1780 문제 풀이를 들고온 Miller 입니다

### 접근 과정

재귀로 풀어야할 것 같은데, 오랫동안 생각해봐도 어떻게 풀어야할지 전혀 몰라서 힌트를 보고 분할 정복으로 풀어야겠다고 생각했습니다. 그런데도 풀이가 안 떠올라서 땃쥐가 참고 문제로 주신 2630 번 문제부터 풀었습니다.

그런데 제가 예전에 풀었던 문제더라구요..? 하지만 그렇다고 풀이가 생각나지는 않았는데,
분할정복을 조금 공부해보고자 병합 정렬 (merge sort) 을 보고 조금 아이디어를 얻었습니다.

분할정복을 할 때 분할 시에 배열의 인덱스를 넘기는 게 아니라 배열 전체를 분할해 넘기는데,
이 문제에서도 마찬가지로 배열 전체를 분할해 넘기고자 했습니다.
하지만 최적의 풀이는 아닌 것 같습니다. 간신히 제한된 시간을 통과한 것 같아요.

### 시간 복잡도

재귀 문제를 다룰 때마다 시간 복잡도를 계산하기 어렵네요. 뭘까요..?