### PR TITLE
[Ader] BOJ (1780) : 종이의 개수 - 문제 풀이

### DIFF
--- a/src/아더/BOJ_1780_종이의개수.java
+++ b/src/아더/BOJ_1780_종이의개수.java
@@ -1,0 +1,71 @@
+package 아더;
+
+import java.io.*;
+
+public class BOJ_1780_종이의개수 {
+
+    static int N;
+    static int[] answers;
+    static int[][] paper;
+
+
+    public static void main(String[] args) {
+        try {
+            input();
+            solve();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private static void solve() {
+        divideConquer(0, 0, N);
+
+        System.out.println(answers[0]);
+        System.out.println(answers[1]);
+        System.out.println(answers[2]);
+    }
+
+    private static void divideConquer(int row, int col, int size) {
+        if (isAllSameNumber(row, col, size)) {
+            answers[paper[row][col] + 1] += 1;
+        } else {
+            int newSize = size / 3;
+
+            for (int i = 0; i < 3; i++) {
+                for (int j = 0; j < 3; j++) {
+                    divideConquer(row + newSize * i, col + newSize * j, newSize);
+                }
+            }
+        }
+    }
+
+    private static boolean isAllSameNumber(int row, int col, int size) {
+        int target = paper[row][col];
+
+        for (int i = row; i < row + size; i++) {
+            for (int j = col; j < col + size; j++) {
+                if (paper[i][j] != target) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    private static void input() throws IOException {
+        //BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedReader br = new BufferedReader(new FileReader(new File("C:\\Users\\k2j38\\OneDrive\\Desktop\\Park\\99.ETC\\input.txt")));
+
+        N = Integer.parseInt(br.readLine());
+        paper = new int[N][N];
+        answers = new int[3];
+
+        for (int i = 0; i < N; i++) {
+            String[] split = br.readLine().split(" ");
+            for (int j = 0; j < N; j++) {
+                paper[i][j] = Integer.parseInt(split[j]);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 안녕하세요 아더입니다~!
이번 문제는 대충 이런식으로 풀어야겠다고 생각은 들었지만 풀이방법이 떠오르지 않아 힌트를 참고했습니다.
분할정복 및 재귀 문제라는 것을 깨닫고 좋은 주제라고 생각했습니다.
최근에 정형화된 코테문제만 풀다보니 요런 주제를 많이 접하지못해 헤맸는데 좋은 기회였습니다!
그리고 땃쥐 PR 메시지를 보았는데 항상 순위에서 1위를 차지하시는 것 같아서 한 번 설명들어보고 싶어요!

## 시간복잡도
정확한 시간복잡도 계산이 어렵네요... 일단 `isAllSameNumber`에서 계속 배열을 순회하고 `divideConquer`에서도 배열을 순회해서 꽤 나올거 같긴합니다....

## 접근 과정
1. 분할정복이라는 키워드를 통해 3분의 1씩 작아질 수 있게 변수를 구성했습니다.
2. 현재 모든 요소가 같은 지를 판단하는 메소드는 2차원 배열을 전부 순회중입니다.(이 부분을 개선할 수 있는지 고민되네요)
3. 정답은 3의 길이를 가진 배열에 차례차례 넣고 출력합니다.(-1, 0, 1의 값들을 가지므로 +1을 해주어 인덱스예외를 방지합니다)

## 삽질 과정
1. 3분의 1씩 줄어든다는 개념은 이해했으나 코드로 옮기는 것에 실패했습니다.
4. 힌트와 다른 사람 풀이를 참고해서 문제를 풀이했습니다  ㅠㅠ


## 이번 문제 해결도 고생많으셨습니다 여러분 👍