### PR TITLE
[산토리] BOJ(2579): 계단 오르기 - 문제풀이

### DIFF
--- a/src/산토리/계단 오르기.py
+++ b/src/산토리/계단 오르기.py
@@ -1,0 +1,26 @@
+# 1칸씩 오르거나 2칸씩 오르거나 할 수 있다.
+# 세칸을 연속으로 오를 수는 없다.
+# 마지막 계단을 무조건 밟아야 한다.
+
+N = int(input())
+
+nums = []
+
+for _ in range(N):
+    nums.append(int(input()))
+
+dp = [[0,0] for _ in range(N)] # dp[m][0]: 1칸씩 이동한 경우, dp[m][1]: 2칸씩 이동한경우
+
+dp[0][0] = nums[0]
+dp[0][1] = 0
+dp[1][0] = dp[0][0] + nums[1]
+dp[1][1] = nums[1]
+
+# n칸에 도착하는 경우는 n-1칸에 오거나 n-2칸에 오거나
+# n-1칸에서 온경우는 n-3칸으로부터 왔어야 한다. n-2칸에서 온경우는 n-3칸에서 오거나 n-4칸에서 오거나
+
+for i in range(2, N):
+    dp[i][0] = max(dp[i-1][1], dp[i-2][0], dp[i-2][1]) + nums[i]
+    dp[i][1] = max(dp[i-2][0], dp[i-2][1]) + nums[i]
+
+print(max(dp[N-1]))

--- a/src/산토리/종이의 개수.py
+++ b/src/산토리/종이의 개수.py
@@ -1,0 +1,52 @@
+# 스택에 직접 배열을 다 담지말고 for문을 탐색할 인덱스만 기록하자
+# 탐색하는 함수를 따로만들어서 답 여부를 확인한다
+
+N = int(input())
+
+board = []
+
+for _ in range(N):
+    board.append(list(map(int, input().split())))
+
+
+stack = []
+stack.append([0,0,N,N])
+
+answer = [0] * 3
+
+def check(r1, c1, r2, c2):
+    start = board[r1][c1]
+
+    if r1 == r2 and c1 == c2:
+        return True
+
+    for r in range(r1, r2):
+        for c in range(c1, c2):
+            if start != board[r][c]:
+                return False
+
+    return True
+
+def get_answer(stack):
+    while stack:
+        r1, c1, r2, c2 = stack.pop()
+
+        if check(r1, c1, r2, c2):
+            answer[board[r1][c1]+1] += 1
+
+        else:
+            unit = (r2-r1)//3
+
+            if unit == 1:
+                for i in range(r1, r2):
+                    for j in range(c1, c2):
+                        answer[board[i][j]+1] += 1
+                continue
+            
+            # print(unit)
+            for i in range(3):
+                for j in range(3):
+                    stack.append([r1+unit*i, c1+unit*j, r1+unit*(i+1), c1+unit*(j+1)])                         
+get_answer(stack)
+for ans in answer:
+    print(ans)


### PR DESCRIPTION
안녕하세요. 산토리입니다.
토요일 문제 풀이 업로드합니다~

## 🐢 접근 과정

예전에 풀어보았던 문제라 쉽게 접근 과정이 떠올랐던 것 같습니다.
N번째 계단에 도착할 때 가능한 경우의 수는 2가지 입니다.
- 1칸을 이동해서 N번째 칸에 도착한 경우
- 2칸을 이동해서 N번째 칸에 도착한 경우

즉, dp 배열에서도 각 칸마다 2가지 경우를 모두 고려해줘야 합니다.
dp[n][0]을 1칸 이동한 경우, dp[n][1]을 2칸 이동한 경우로 생각했습니다.

1. 1칸 이동한 경우

1칸 이동한 경우에는 n-1번째 칸을 1칸을 움직여 도착한 경우는 불가능합니다. 연달아 3칸을 밟을 수 없기 때문입니다. 

그래서 max(n-1번째 칸을 2칸 움직여 도착한 경우, n-2번째 칸을 1칸이나 2칸 움직여 도착한 경우)
+ n번째 칸의 점수로 갱신합니다.

2. 2칸 이동한 경우

2칸 이동한 경우는 n-2번째 칸에 어떻게 몇칸을 이동해 도착했는지 상관 없으므로 단순하게 계산이 가능합니다.

max(n-2번째 칸에 1칸이나 2칸 움직여 도착한 경우) + n번째 칸의 점수로 갱신합니다.

마지막에는 N번째 칸 중 1칸 움직인 것과 2칸 움직여 도착한 경우 중 큰 값을 반환합니다. 

## 😡 삽질 과정
처음에는 dp를 2차원으로 관리할 생각을 못했는데 하다보니 생각이 났습니다.

##  🕖 시간 복잡도
결국 계단의 수 N만큼만 계산하므로 O(N)입니다.