### PR TITLE
[땃쥐] BOJ(2579): 계단 오르기 - 문제풀이

### DIFF
--- a/src/땃쥐/BOJ_2579.java
+++ b/src/땃쥐/BOJ_2579.java
@@ -1,0 +1,50 @@
+package 땃쥐;
+
+import java.io.IOException;
+
+public class BOJ_2579 {
+
+    private static int[] stair;
+    private static Integer[] maxScores;
+
+    public static void main(String[] args) throws IOException {
+        int N = readInt();
+
+        stair = new int[N + 1];
+        maxScores = new Integer[N + 1];
+
+        for (int i = 1; i <= N; i++) {
+            stair[i] = readInt(); // 계단 초기화
+        }
+
+        maxScores[0] = stair[0];
+        maxScores[1] = stair[1];
+
+        if (N >= 2) {
+            maxScores[2] = stair[1] + stair[2];
+        }
+        int maxScore = calMaxScore(N);
+        System.out.print(maxScore);
+    }
+
+    private static int calMaxScore(int k) {
+        if (maxScores[k] == null) {
+            maxScores[k] = Math.max(calMaxScore(k - 3) + stair[k - 1], calMaxScore(k - 2)) + stair[k];
+        }
+        return maxScores[k];
+    }
+
+    private static int readInt() throws IOException {
+        int value = 0;
+        while (true) {
+            // 입력 문자의 ASCII코드 값.
+            // 가령 '0'이 들어왔으면 숫자 0이 아니라 '0'의 ASCII 코드값인 48이다.
+            int input = System.in.read();
+            if (input == '\n') { // 개행문자면 연산을 끊음
+                return value; // 그냥 반환
+            } else {
+                value = value * 10 + (input - 48); // 기존 값을 10배하고 입력된 추가값을 파싱하여 더함
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 안녕하세요
문제를 풀려고 몇 번 시도해봤지만 이해하기 힘들어서 답을 좀 봤습니다. ㅜㅜ;

## 삽질?

일단 계단을 몇 번 그려보고 가지케이스로 테스트 케이스를 몇 번 그려보면서 '룰'을 이해하려는 시도를 해봤습니다. 도저히 제가 가진 지식으로 처리할 수 없어서 힌트를 봤습니다. 

DP라는 것이 이전 단계까지의 과정을 저장해두고 다시 꺼내씀으로서 한번 계산하는 것을 다시 계산하지 않는 기법이라는것을 배웠지만, 실제 문제 풀때는 바로 적용되지않네요. 그래서 또 답을 봤습니다

---

## 풀이 해석

N번째 계단에 도달하는 경우는 결국 두가지로 이분됩니다.

1. 한칸 아래에서 올라오거나.
2. 두칸 아래에서 바로 올라오거나.

두칸 아래에서 올라오는 경우에는, 연속해서 세 계단이 와선 안 된다는 제약 하에서 자유롭습니다. 그 아래에서 어떻게 오든, 두칸 아래에서 오는 경우는 조건에서 문제가 되지 않습니다.

하지만, 한칸 아래에서 올라오는 경우에는, 두칸 아래-한칸아래와 같은 상황에서 올라왔을 경우에는 규칙을 어기는 접근이 되버립니다. 한칸 아래에서 올라올 경우에는 세칸 아래에서 건너 뛰어 한칸 아래에 오고, 한칸 아래에서 다음 칸으로 와야할 수밖에 없습니다.

```java
    private static int calMaxScore(int k) {
        if (maxScores[k] == null) {
            maxScores[k] = Math.max(calMaxScore(k - 3) + stair[k - 1], calMaxScore(k - 2)) + stair[k];
        }
        return maxScores[k];
    }
```
k번째 칸에 오기까지의 조건을 재귀함수를 통해 정의하면 다음과 같습니다.
(k가 3보다 작을 경우에는 인덱스가 음의 값이 되버려서, IndexOut 머시깽이 Exception이 터지는데 앞에서 미리 초기화를 해둬야합니다.)

```java
        maxScores[0] = stair[0];
        maxScores[1] = stair[1];

        if (N >= 2) {
            maxScores[2] = stair[1] + stair[2];
        }
```
- 0일 때는 0으로 취급합니다.
- 1일 때는 1번째 칸밖에 없으니 1번 계단값을 초기화합니다.
- 2일 때는 1번째 칸, 2번째 칸의 합으로만 구성할 수 있습니다.
- 주의할 점은 N으로 1이 들어왔을 경우입니다. 이 경우 인덱스 초과 문제가 발생할 수 있으니 조건부로 초기화해줘야합니다.


---

## 시간복잡도

![image](https://user-images.githubusercontent.com/88282356/159165580-f65ccbc1-beac-49af-9a4a-f9db0383ccdb.png)
120ms

결국 N,N-1,N-2,...1까지 모든 최댓값을 한번씩 계산해야하고 저장할 필요성이 있으므로 시간 복잡도는 O(N)이 됩니다.


---
