### PR TITLE
[Jay] BOJ (1780) : 종이의 개수 - 문제 풀이

### DIFF
--- a/src/제이/week3/BOJ_1780.java
+++ b/src/제이/week3/BOJ_1780.java
@@ -1,0 +1,96 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.awt.Point;
+
+public class BOJ_1780 {
+
+    private static int paperSize;
+    private static int[][] paper;
+
+    private static int minusOneCount;
+    private static int zeroCount;
+    private static int oneCount;
+
+    public static void main(String[] args) throws IOException {
+        readInput();
+
+        int firstValue = paper[0][0];
+
+        if (isAllSame(paperSize, new Point(0, 0), firstValue)) {
+            addCountOfNumber(firstValue);
+        } else {
+            recursive(new Point(0,0), paperSize);
+        }
+        System.out.println(minusOneCount);
+        System.out.println(zeroCount);
+        System.out.println(oneCount);
+    }
+
+    private static void recursive(Point startPoint, int size) {
+        int splitedSize = size / 3;
+
+        for (int y = 0; y < 3; y++) {
+            for (int x = 0; x < 3; x++) {
+                int nx = startPoint.x + (x * splitedSize);
+                int ny = startPoint.y + (y * splitedSize);
+
+                int firstValue = paper[ny][nx];
+
+                if (splitedSize == 1) {
+                    addCountOfNumber(paper[ny][nx]);
+                    continue;
+                }
+
+                boolean allSame = isAllSame(splitedSize, new Point(nx, ny), firstValue);
+
+                if (allSame) {
+                    addCountOfNumber(firstValue);
+                } else {
+                    recursive(new Point(nx, ny), splitedSize);
+                }
+            }
+        }
+    }
+
+    private static boolean isAllSame(int splitedSize, Point startPoint, int firstValue) {
+        boolean allSame = true;
+
+        int nx = startPoint.x;
+        int ny = startPoint.y;
+
+        for (int y = ny; y < ny + splitedSize; y++) {
+            for (int x = nx; x < nx + splitedSize; x++) {
+                int curValue = paper[y][x];
+                allSame = (firstValue == curValue);
+
+                if (!allSame) {
+                    y = ny + splitedSize;
+                    break;
+                }
+            }
+        }
+
+        return allSame;
+    }
+
+    private static void readInput() throws IOException {
+        BufferedReader reader = new BufferedReader(new InputStreamReader(System.in));
+
+        paperSize = Integer.parseInt(reader.readLine());
+        paper = new int[paperSize][paperSize];
+
+        for (int i = 0; i < paperSize; i++) {
+            String[] row = reader.readLine().split(" ");
+            for (int j = 0; j < row.length; j++) {
+                paper[i][j] = Integer.parseInt(row[j]);
+            }
+        }
+    }
+
+    private static void addCountOfNumber(int num) {
+        if (num == -1) minusOneCount++;
+        else if (num == 0) zeroCount++;
+        else if (num == 1) oneCount++;
+    }
+}


### PR DESCRIPTION
안녕하세요 Jay 입니다.
먼저 늦게 제출하는점 죄송하다는 말씀 드리고, 기다려주신 땃선생님과 다른 선생님들께 감사드립니다 ㅠㅠ

이번 문제는 고민을 해봐도 도저히 감이 안와서, 알고리즘 분류만 참고하였습니다.

# 시간 복잡도

재귀 문제는 시간 복잡도 계산이 어려운것 같습니다...
그런데 결국 전체 종이를 다 확인해야하니, O(N^2) 인것 같기도 한데.. 확신은 들지 않네요.

# 접근 과정

`분할 정복` 과 `재귀` 라는 키워드를 통해 한 페이지씩 확인 후 재귀 호출을 통해 더 작은 페이지를 확인하는 방식으로 접근하였습니다.
재귀호출을 할때, 기존 크기의 1/3 만큼만 탐색하도록 구현하였습니다.

# 삽질

키워드를 얻기 전에는 BFS 로 풀어야 할까 아주 잠깐 고민했었는데,
BFS 로 풀이할 수 있는 문제가 아닌것 같아 알고리즘 분류만 확인하였고,
키워드를 얻고 나서는 크게 삽질 과정은 없었던 것 같습니다..!