### PR TITLE
[Jay] BOJ (2579) : 계단 오르기 - 문제 풀이

### DIFF
--- a/src/제이/week3/BOJ_1780.java
+++ b/src/제이/week3/BOJ_1780.java
@@ -1,0 +1,96 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.awt.Point;
+
+public class BOJ_1780 {
+
+    private static int paperSize;
+    private static int[][] paper;
+
+    private static int minusOneCount;
+    private static int zeroCount;
+    private static int oneCount;
+
+    public static void main(String[] args) throws IOException {
+        readInput();
+
+        int firstValue = paper[0][0];
+
+        if (isAllSame(paperSize, new Point(0, 0), firstValue)) {
+            addCountOfNumber(firstValue);
+        } else {
+            recursive(new Point(0,0), paperSize);
+        }
+        System.out.println(minusOneCount);
+        System.out.println(zeroCount);
+        System.out.println(oneCount);
+    }
+
+    private static void recursive(Point startPoint, int size) {
+        int splitedSize = size / 3;
+
+        for (int y = 0; y < 3; y++) {
+            for (int x = 0; x < 3; x++) {
+                int nx = startPoint.x + (x * splitedSize);
+                int ny = startPoint.y + (y * splitedSize);
+
+                int firstValue = paper[ny][nx];
+
+                if (splitedSize == 1) {
+                    addCountOfNumber(paper[ny][nx]);
+                    continue;
+                }
+
+                boolean allSame = isAllSame(splitedSize, new Point(nx, ny), firstValue);
+
+                if (allSame) {
+                    addCountOfNumber(firstValue);
+                } else {
+                    recursive(new Point(nx, ny), splitedSize);
+                }
+            }
+        }
+    }
+
+    private static boolean isAllSame(int splitedSize, Point startPoint, int firstValue) {
+        boolean allSame = true;
+
+        int nx = startPoint.x;
+        int ny = startPoint.y;
+
+        for (int y = ny; y < ny + splitedSize; y++) {
+            for (int x = nx; x < nx + splitedSize; x++) {
+                int curValue = paper[y][x];
+                allSame = (firstValue == curValue);
+
+                if (!allSame) {
+                    y = ny + splitedSize;
+                    break;
+                }
+            }
+        }
+
+        return allSame;
+    }
+
+    private static void readInput() throws IOException {
+        BufferedReader reader = new BufferedReader(new InputStreamReader(System.in));
+
+        paperSize = Integer.parseInt(reader.readLine());
+        paper = new int[paperSize][paperSize];
+
+        for (int i = 0; i < paperSize; i++) {
+            String[] row = reader.readLine().split(" ");
+            for (int j = 0; j < row.length; j++) {
+                paper[i][j] = Integer.parseInt(row[j]);
+            }
+        }
+    }
+
+    private static void addCountOfNumber(int num) {
+        if (num == -1) minusOneCount++;
+        else if (num == 0) zeroCount++;
+        else if (num == 1) oneCount++;
+    }
+}

--- a/src/제이/week3/BOJ_2579.java
+++ b/src/제이/week3/BOJ_2579.java
@@ -1,0 +1,47 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+import static java.lang.Math.max;
+
+public class BOJ_2579 {
+
+    private static int size;
+    private static int[] scores;
+    private static int[] maxScores;
+
+    public static void main(String[] args) throws IOException {
+        readInput();
+
+        maxScores[0] = scores[0];
+
+        if (scores.length >= 2){
+            maxScores[1] = scores[0] + scores[1];
+
+            if (scores.length >= 3) {
+                maxScores[2] = max(scores[0] + scores[2], scores[1] + scores[2]);
+
+                for (int i = 3; i < size; i++) {
+                    int calc1 = maxScores[i-2] + scores[i];
+                    int calc2 = maxScores[i-3] + scores[i-1] + scores[i];
+                    maxScores[i] = Math.max(calc1, calc2);
+                }
+            }
+        }
+
+        System.out.println(maxScores[size - 1]);
+    }
+
+    private static void readInput() throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        size = Integer.parseInt(br.readLine());
+
+        scores = new int[size];
+        maxScores = new int[size];
+
+        for (int i = 0; i < size; i++) {
+            scores[i] = Integer.parseInt(br.readLine());
+        }
+    }
+}


### PR DESCRIPTION
# 시간 복잡도

DP 를 이용하여 풀이하였기 때문에, 시간 복잡도는 O(n) 입니다.

# 접근 과정

여러 삽질 끝에 DP 로 문제풀이를 하려고 했고, 각 번째를 한 번만 구하려면 결국 식이 필요했습니다.
재귀로 계산하면 한 계단을 여러번 계산해서 비교해야 하기 때문에, 시간복잡도를 줄일 수 없어서 시간 초과가 발생합니다.
고민하던 중 예전에 밀러의 접근 방식 중 점화식을 정의하고 문제를 풀었던 것을 인상깊게 본 기억이 났습니다.
그래서 이번 문제를 잘 살펴보다 보니 점화식을 정의할 수 있을 것 같아서 시도해봤습니다.

### 점화식

1. `n 번째의 합` = `n-2 번째 까지의 합` + `n 번째 계단 점수`
2. `n 번째의 합` = `n-3 번째 까지의 합` + `n-1 번째 계단 점수` + `n 번째 계단 점수`

1과 2 중 큰 것을 `n 번째의 합`으로 지정합니다.

```java
for (int i = 3; i < size; i++) {
    int calc1 = maxScores[i-2] + scores[i];
    int calc2 = maxScores[i-3] + scores[i-1] + scores[i];
    maxScores[i] = Math.max(calc1, calc2);
}
```

# 삽질

처음에 재귀를 통한 계산으로 제일 마지막 계단의 최대값을 구하려 했습니다.
이 방법으로 계산하면 정답은 나올 것 같았지만, 시간복잡도를 줄일 수 없는 방법이었습니다,

그래서 이번 문제도 알고리즘 분류를 참고하여 문제를 풀이했습니다..ㅠㅠ
(언제쯤 힌트 없이 풀 수 있을까요..)