### PR TITLE
[Miller] BOJ(2579): 계단 오르기 - 문제풀이

### DIFF
--- a/src/밀러/BOJ_2579.py
+++ b/src/밀러/BOJ_2579.py
@@ -1,0 +1,31 @@
+from typing import List
+
+
+def solution(n: int, stairs: List[int]) -> int:
+
+    answer: List[int] = [0 for _ in range(n + 1)]
+
+    def recursion(m: int):
+        if m == 0:
+            return stairs[0]
+        if m == 1:
+            return stairs[1]
+        if m == 2:
+            return stairs[1] + stairs[2]
+        if answer[m]:
+            return answer[m]
+
+        answer[m] = stairs[m] + max(recursion(m - 2), stairs[m - 1] + recursion(m - 3))
+        return answer[m]
+
+    return recursion(n)
+
+
+if __name__ == "__main__":
+    N: int = int(input())
+    arr: List[int] = [0]
+
+    for _ in range(N):
+        arr.append(int(input()))
+
+    print(solution(N, arr))


### PR DESCRIPTION
늦게 올려서 죄송합니다 ㅠㅠ 2579번 풀이를 가져온 Miller 입니다.

### 접근 과정

계단을 오르는 것을 보고 피보나치 수열처럼 점화식으로 풀어야겠다고 생각했습니다.
그리고 어떤 계단 위치에 있을 때, 해당 위치로 반드시 와야하는 경우를 따져보았습니다.

<img src="https://user-images.githubusercontent.com/50660684/159247057-0a95234a-3b75-4373-86be-7ac437c84a34.jpg" width=500 />

두 칸 아래에서 이동했을 경우, 두 칸 아래보다 아래에서는 어떤 일이 벌어지든 상관없습니다.
따라서 아래와 같이 점화식을 세울 수 있었습니다.

```python
answer[m] = stairs[m] + max(recursion(m - 2), stairs[m - 1] + recursion(m - 3))
```

인덱스가 헷갈릴 것 같아, 입력을 받을 때 맨 앞에 시작점의 점수를 0 으로 추가했습니다.
이렇게 하면 n 번째 계단 = stairs[n] 으로 되어 생각이 간편해졌습니다.

### 삽질과정

재귀만으로 풀고 문제를 제출했더니 바로 시간초과가 떴습니다.
배열에 저장하고 풀었더니 통과되었습니다. 메모이제이션 최고!