### PR TITLE
[산토리] BOJ(14888): 연산자 끼워넣기 - 문제풀이

### DIFF
--- a/src/산토리/연산자 끼워넣기.py
+++ b/src/산토리/연산자 끼워넣기.py
@@ -1,0 +1,41 @@
+from copy import deepcopy
+N = int(input())
+
+nums = list(map(int, input().split()))
+
+operators = list(map(int, input().split())) # 덧셈, 뺄셈, 곱셈, 나눗셈
+
+# 최대 10!/3!3!3! 의 가능성
+
+# 재귀를 하면서 operator가 없을 때까지 반복?
+
+results = []
+
+
+def calculate(num, cnt, op_arr):
+    if cnt == N:
+        results.append(num)
+        return
+
+    # 같은 것이 있는 순열 처리가 제대로 된다
+    for i, operator in enumerate(op_arr):
+        if operator > 0:
+            new_operator = deepcopy(op_arr)
+            new_operator[i] -= 1
+            if i == 0:
+                calculate(num+nums[cnt], cnt+1, new_operator)
+            elif i == 1:
+                calculate(num-nums[cnt], cnt+1, new_operator)
+            elif i == 2:
+                calculate(num*nums[cnt], cnt+1, new_operator)
+            else:
+                if num > 0:
+                    new_num = num//nums[cnt]
+                else:
+                    new_num = -((-num)//nums[cnt])
+                calculate(new_num, cnt+1, new_operator)
+
+
+calculate(nums[0], 1, operators)
+print(max(results))
+print(min(results))


### PR DESCRIPTION
안녕하세요. 산토리입니다.
화요일 문제 풀이 업로드합니다~

## 🐢 접근 과정

그리디적으로 수식의 최소, 최대를 결정하기에는 생각할 것이 너무 많아보여서 모든 경우의 수를 다 뒤져보는 방법을 선택했습니다. 
DFS와 같이 수행해보면 좋을 것 같아서 재귀를 통해 풀었습니다.

![image](https://user-images.githubusercontent.com/54302155/159511420-873a5db5-bf2e-455f-a07c-cb31d51dae06.png)

각 연산자의 순서에 따라서 가지치기를 해가면서 재귀로 계산하면 모든 경우의 수가 저장될 것입니다. 

`calculate` 함수가 호출되면 연산자 개수가 저장된 배열을 순회합니다. 
남은 연산자가 있으면 해당 연산자의 개수를 하나 깎고 계산한 결과와 남은 연산자 개수를 담아 재귀호출합니다. 이 때 재귀호출 종료조건은 숫자의 개수가 주어진 숫자의 개수와 같아질 때입니다.
모든 숫자를 계산했으면 결과 배열에 저장하고 return합니다.  

## 😡 삽질 과정
삽질 과정은 아니고 이렇게 연산자의 경우의 수를 세면 같은 것이 있는 순열이라서 중복되는 경우도 셀 것이라고 생각했습니다. 
그래서 시간 초과가 나지 않을까했는데 어차피 for문으로 가지치기를 하기 때문에 각 경우를 한번만 순회한다는 것을 알게 되었습니다. 

##  🕖 시간 복잡도
연산자를 배치하는 경우의 수가 대략 (N-1)! / ((N/4)!^4) 의 경우의 수를 가지는데 N이 커질수록 O(N!)에 접근할 것 같습니다.
문제에서는 최대 N이 11밖에 되지 않아서 만 여번정도만 계산하면 돼서 문제가 없는 것 같습니다.