### PR TITLE
[Miller] BOJ(14888) : 연산자 끼워넣기 - 문제 풀이

### DIFF
--- a/src/밀러/BOJ_14888.py
+++ b/src/밀러/BOJ_14888.py
@@ -1,0 +1,66 @@
+import sys
+from typing import List
+
+
+def solution(N: int, nums: List[int], rest: List[int]):
+    routes: List[List[int]] = []
+
+    def dfs(route: List[int]):
+
+        if len(route) == N - 1:
+            routes.append(route[:])
+
+        for dest in range(len(rest)):
+            if not rest[dest]:
+                continue
+
+            rest[dest] -= 1
+            route.append(dest)
+            dfs(route)
+
+            rest[dest] += 1
+            route.pop()
+
+    dfs([])
+
+    min_num: int = sys.maxsize
+    max_num: int = -sys.maxsize
+
+    def operate(left: int, right: int, op: int):
+        if op == 0:
+            return left + right
+        elif op == 1:
+            return left - right
+        elif op == 2:
+            return left * right
+        else:
+            if left * right < 0:
+                return -(abs(left) // abs(right))
+            return left // right
+
+    for route in routes:
+        stack: List[int] = list(reversed(nums))
+        ops: List[int] = list(reversed(route))
+
+        while len(stack) != 1:
+            left: int = stack.pop()
+            right: int = stack.pop()
+            op: int = ops.pop()
+
+            stack.append(operate(left, right, op))
+
+        min_num = min(min_num, stack[0])
+        max_num = max(max_num, stack[0])
+
+    return min_num, max_num
+
+
+if __name__ == "__main__":
+    N: int = int(input())
+    nums: List[int] = list(map(int, input().split()))
+    rest: List[int] = list(map(int, input().split()))
+
+    min_num, max_num = solution(N, nums, rest)
+
+    print(max_num)
+    print(min_num)


### PR DESCRIPTION
안녕하세요, BOJ 14888번 풀이를 들고 온 Miller 입니다 🤿
PR 을 늦게 올려서 죄송합니다 ㅠㅠ

## 접근 과정

이 문제를 봤을 때 순열/조합 문제이므로 DFS 와 백트래킹을 이용하고자 했습니다.

이 문제의 각 연산자인 `+`, `-`, `*`, `//` 는 아래와 같은 그래프 구조를 가지고 있습니다. 

<img src="https://user-images.githubusercontent.com/50660684/159899199-9491e1b8-9700-484e-b434-03d662dc07ff.png" width=400 />

그리고 문제의 에시에 나온 것처럼 각 `+`, `-`, `*`, `//` 가 각각 2, 1, 1, 1 개로 주어진다면,
`rest` 라는 배열을 [2, 1, 1, 1] 로 구성하고, 해당 노드에 방문할 경우 해당 `rest` 에서 해당 인덱스에서 -1 합니다.
그리고 방문한 노드는 `route` 배열에 방문한 노드를 추가합니다.

예를 들면 맨 처음 `+` 를 방문하면 `rest` 는 [1, 1, 1, 1], `route` 는 [0]
다시 `+` 를 방문하면 `rest` 는 [0, 1, 1, 1], `route` 는 [0, 0] 이 됩니다.

이런식으로 각 노드를 방문하다가 `route` 의 길이가 5가 되면,
전역 변수인 `routes` 에 해당 `route` 를 복사해 추가합니다.
결과적으로 `routes` 는 같은 것을 포함하는 순열의 모든 경우의 수로 구성된 배열로, 위의 예에서는 총 60개의 원소를 가집니다.


### 경우의 수 계산 -> 백트래킹

`dfs()` 함수로 어떤 노드에 접근한 뒤에 해당 노드에 연결된 다른 노드를 모두 순회한 뒤에는
`rest` 배열에서 해당 노드의 인덱스에서 +1 하고, `route` 배열에서 가장 최근에 추가된 노드를 `pop()` 합니다.
즉, 현재 노드에서 상위 노드로 다시 back 할 때, 원상복구 시켜놓고 돌아갑니다.

<img src="https://user-images.githubusercontent.com/50660684/159897501-6c24bd19-649b-429c-964b-bcc12cdea05d.png" width=600 />

이런 식으로 백트래킹이 이루어집니다.


### 수식 계산 -> 스택

이 문제를 풀면서 느낀 건 단순히 같은 것이 포함된 순열의 경우의 수를 모두 구하는 문제가 아니라,
계산 까지 생각해야 된다는 것이었습니다.

60개의 경우의 수 (그래프 내 경로) 를 구한 뒤에는, 각 수식을 계산해야하는데 스택을 이용했습니다.
숫자 배열 앞에서 2개씩 숫자를 뽑고, 경로에서 1개씩 연산자를 뽑아 계산하고 다시 결과를 스택의 맨 앞에 넣습니다.

그리고 다시 숫자 배열 앞에서 2개씩 숫자, 경로에서 1개씩 연산자를 뽑아 계산하고
결과를 스택의 맨 앞에 넣는 동작을 반복합니다.
결과적으로 스택에 맨 마지막에 남는 1개의 원소는 수식 계산 결과입니다.

(실제 계산 시에는 숫자 배열과 경로를 뒤집어, 스택의 맨 뒤에서 입출력이 나오도록 했습니다.)

아쉽게도 현재 제 풀이는 공간 복잡도가 꽤 높습니다.. 아마 수식 계산을 경로를 구할 때 동시에 해야할 것 같습니다.