### PR TITLE
[땃] BOJ(14888) : 연산자 끼워넣기 - 문제 풀이

### DIFF
--- a/src/땃쥐/BOJ_14888_1.java
+++ b/src/땃쥐/BOJ_14888_1.java
@@ -1,0 +1,87 @@
+package 땃쥐;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.IntBinaryOperator;
+
+public class BOJ_14888_1 {
+
+    private static int max = Integer.MIN_VALUE;
+    private static int min = Integer.MAX_VALUE;
+
+    private static int[] numbers;
+    private static List<IntBinaryOperator> functions = new ArrayList<>();
+
+    private static boolean visited[];
+    private static IntBinaryOperator plus = (x, y) -> x + y;
+    private static IntBinaryOperator minus = (x, y) -> x - y;
+    private static IntBinaryOperator multiply = (x, y) -> x * y;
+    private static IntBinaryOperator divide = (x, y) -> x / y;
+
+    private static int N;
+
+    public static void main(String[] args) throws IOException {
+        N = readInt();
+        numbers = new int[N];
+        visited = new boolean[N - 1];
+
+        for (int i = 0; i < N; i++) {
+            numbers[i] = readInt();
+        }
+
+        int numberOfPlus = readInt();
+        int numberOfMinus = readInt();
+        int numberOfMultiply = readInt();
+        int numberOfDivide = readInt();
+
+        for (int i = 0; i < numberOfPlus; i++) {
+            functions.add(plus);
+        }
+        for (int i = 0; i < numberOfMinus; i++) {
+            functions.add(minus);
+        }
+        for (int i = 0; i < numberOfMultiply; i++) {
+            functions.add(multiply);
+        }
+        for (int i = 0; i < numberOfDivide; i++) {
+            functions.add(divide);
+        }
+        bt(numbers[0], 0);
+        StringBuilder sb = new StringBuilder();
+        sb.append(max).append('\n').append(min);
+        System.out.print(sb);
+    }
+
+    public static void bt(int currentValue, int depth) {
+        if (depth == N - 1) {
+            max = Math.max(max, currentValue);
+            min = Math.min(min, currentValue);
+            return;
+        }
+        for (int i = 0; i < N - 1; i++) { // 0,1,2,3,...,N-2
+            if (!visited[i]) {
+                visited[i] = true;
+                bt(functions.get(i).applyAsInt(currentValue, numbers[depth + 1]), depth + 1);
+                visited[i] = false;
+            }
+        }
+    }
+
+    private static int readInt() throws IOException {
+        int value = 0;
+        boolean negative = false;
+
+        int input;
+        while (true) {
+            input = System.in.read();
+            if (input == ' ' || input == '\n') {
+                return (negative) ? -value : value;
+            } else if (input == '-') {
+                negative = true;
+            } else {
+                value = value * 10 + (input - 48);
+            }
+        }
+    }
+}

--- a/src/땃쥐/BOJ_14888_2.java
+++ b/src/땃쥐/BOJ_14888_2.java
@@ -1,0 +1,71 @@
+package 땃쥐;
+
+import java.io.IOException;
+
+public class BOJ_14888_2 {
+
+
+    private static int max = Integer.MIN_VALUE;
+    private static int min = Integer.MAX_VALUE;
+
+    private static int[] numbers;
+    private static int[] operatorCounter = new int[4];
+    private static int N;
+
+    public static void main(String[] args) throws IOException {
+        N = readInt();
+        numbers = new int[N];
+        for (int i = 0; i < N; i++) {
+            numbers[i] = readInt();
+        }
+        for (int i=0; i<4; i++) {
+            operatorCounter[i] = readInt();
+        }
+        bt(numbers[0], 0);
+        StringBuilder sb = new StringBuilder();
+        sb.append(max).append('\n').append(min);
+        System.out.print(sb);
+    }
+
+    public static void bt(int currentValue, int depth) {
+        if (depth == N - 1) {
+            max = Math.max(max, currentValue);
+            min = Math.min(min, currentValue);
+            return;
+        }
+        for (int i = 0; i < 4; i++) {
+            if (operatorCounter[i] >0) {
+                operatorCounter[i] --;
+
+                if (i==0) {
+                    bt(currentValue + numbers[depth + 1], depth + 1);
+                } else if (i==1) {
+                    bt(currentValue - numbers[depth + 1], depth + 1);
+                } else if (i==2) {
+                    bt(currentValue * numbers[depth + 1], depth + 1);
+                } else {
+                    bt(currentValue / numbers[depth + 1], depth + 1);
+                }
+
+                operatorCounter[i] ++;
+            }
+        }
+    }
+
+    private static int readInt() throws IOException {
+        int value = 0;
+        boolean negative = false;
+
+        int input;
+        while (true) {
+            input = System.in.read();
+            if (input == ' ' || input == '\n') {
+                return (negative) ? -value : value;
+            } else if (input == '-') {
+                negative = true;
+            } else {
+                value = value * 10 + (input - 48);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 땃땃

안녕하세요. 풀 리퀘스트 드립니다. 문제 제출 늦게해서 죄송합니다...

## 삽질과정
- 일단 내용 자체를 이해하지 못 해서 힌트를 봤습니다. 힌트를 봐도 백트래킹이 몰라서, 더 [간단한 난이도의 문제](https://www.acmicpc.net/problem/15649)를 잠시 해답을 참고하고 풀어봤습니다. 
- 힌트를 보면서 풀었음에도 깊이에서 뭔가 연산 결과가 어긋나거나, 하는 경우가 계속 발생해서 2-3시간 이상을 날린 것 같습니다.

## 접근과정

### 풀이 1
```java

    public static void bt(int currentValue, int depth) {
        if (depth == N - 1) {
            max = Math.max(max, currentValue);
            min = Math.min(min, currentValue);
            return;
        }
        for (int i = 0; i < N - 1; i++) { // 0,1,2,3,...,N-2
            if (!visited[i]) {
                visited[i] = true;
                bt(functions.get(i).applyAsInt(currentValue, numbers[depth + 1]), depth + 1);
                visited[i] = false;
            }
        }
    }
```
- ArrayList에 N-1개의 IntBinaryOperator를 순서대로 넣었습니다.(+,-,*,/)
- 각 인덱스에 접근했는지 여부를 boolean 배열에 기록하고 백트래킹에 사용합니다.
- 최대 깊이보다 더 깊은 깊이에 도달했을 때 최대 최소를 갱신합니다.
- 이 방식은 420ms정도 시간 걸립니다.

---

### 풀이2
```java
    public static void bt(int currentValue, int depth) {
        if (depth == N - 1) {
            max = Math.max(max, currentValue);
            min = Math.min(min, currentValue);
            return;
        }
        for (int i = 0; i < 4; i++) {
            if (operatorCounter[i] >0) {
                operatorCounter[i] --;

                if (i==0) {
                    bt(currentValue + numbers[depth + 1], depth + 1);
                } else if (i==1) {
                    bt(currentValue - numbers[depth + 1], depth + 1);
                } else if (i==2) {
                    bt(currentValue * numbers[depth + 1], depth + 1);
                } else {
                    bt(currentValue / numbers[depth + 1], depth + 1);
                }

                operatorCounter[i] ++;
            }
        }
    }
```
- 연산자의 사용가능횟수를 길이가 4인 배열에 순서대로 저장합니다.
- 카운터의 값이 0보다 큰지를 기준으로 사용가능여부를 판단하고 백트래킹에 사용합니다.
- 풀이 1의 방식은 동일한 종류의 연산자를 같은 깊이에서 여러번 사용할 가능성이 있지만, 이 방식은 종류별로 카운터를 기준으로 판단하기에 같은 깊이에서 동일한 연산자를 다시 트래킹하지 않아도 되기에 시간복잡도 면에서 더 이득입니다.
- 최대 깊이보다 더 깊은 깊이에 도달했을 때 최대 최소를 갱신합니다.

---

## 시간복잡도

![image](https://user-images.githubusercontent.com/88282356/159901656-fc85e5a6-ca85-4784-9cc9-64bb1c9d90f3.png)

128ms


- 연산자의 중복 갯수 여부에 따라 시간복잡도가 달라질 수 있어서 정형화하기 힘들 것 같습니다.

---
