### PR TITLE
[Jay] BOJ (16918) : 봄버맨- 문제 풀이

### DIFF
--- a/src/제이/week4/BOJ_16918.java
+++ b/src/제이/week4/BOJ_16918.java
@@ -1,0 +1,105 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class BOJ_16918 {
+
+    private static final char CHR_EMPTY = '.';
+    private static final char CHR_BOMB = 'O';
+    private static final int BOMB_INIT_TIME = 3;
+    private static final int EMPTY = 0;
+
+    private static int row;
+    private static int col;
+    private static int timeLimit;
+    private static int[][] map;
+
+    private static int[] x_move = {0,0,-1,1};
+    private static int[] y_move = {-1,1,0,0};
+
+    public static void main(String[] args) throws IOException {
+        readInput();
+
+        int time = 1;
+        processBomb(map);
+
+        boolean isInstallTurn = true;
+
+        while(time < timeLimit) {
+            time++;
+
+            if (isInstallTurn) {
+                installOrProcessBomb(map);
+            } else {
+                processBomb(map);
+            }
+
+            isInstallTurn = !isInstallTurn;
+        }
+
+        StringBuilder sb = new StringBuilder();
+        for (int[] r : map) {
+            for (int c : r) {
+                if (c == 0) sb.append(CHR_EMPTY);
+                else sb.append(CHR_BOMB);
+            }
+            sb.append("\n");
+        }
+        System.out.println(sb);
+    }
+
+    private static void readInput() throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        String[] firstRow = br.readLine().split(" ");
+        row = Integer.parseInt(firstRow[0]);
+        col = Integer.parseInt(firstRow[1]);
+        timeLimit = Integer.parseInt(firstRow[2]);
+        map = new int[row][col];
+
+        for (int y = 0; y < row; y++) {
+            String line = br.readLine();
+            for (int x = 0; x < line.length(); x++) {
+                if (line.charAt(x) == CHR_BOMB)
+                    map[y][x] = BOMB_INIT_TIME;
+            }
+        }
+    }
+
+    private static void installOrProcessBomb(int[][] map) {
+        for (int y = 0; y < map.length; y++) {
+            for (int x = 0; x < map[0].length; x++) {
+                if (map[y][x] == EMPTY) {
+                    map[y][x] = BOMB_INIT_TIME;
+                } else {
+                    map[y][x]--;
+                }
+            }
+        }
+    }
+
+    private static void processBomb(int[][] map) {
+        for (int y = 0; y < map.length; y++) {
+            for (int x = 0; x < map[0].length; x++) {
+                if (map[y][x] == EMPTY) continue;
+
+                map[y][x]--;
+
+                if (map[y][x] == EMPTY) {
+                    fireBomb(map, x, y);
+                }
+            }
+        }
+    }
+
+    private static void fireBomb(int[][] map, int x, int y) {
+        for (int i = 0; i < 4; i++) {
+            int nx = x + x_move[i];
+            int ny = y + y_move[i];
+
+            if (ny < 0 || ny >= map.length || nx < 0 || nx >= map[0].length) continue;
+            if (map[ny][nx] == 1) continue;
+
+            map[ny][nx] = EMPTY;
+        }
+    }
+}


### PR DESCRIPTION
# 시간 복잡도

생각했던 풀이 방식은 O(N^3) 의 시간복잡도를 가집니다.
문제의 입력에 따라 최대 `8,000,000` 번의 좌표 확인을 하는데, 폭탄이 터질 경우 각 좌표의 상하 좌우를 확인합니다.
그래서 이에 `4`를 곱하여 `32,000,000` 번의 연산을 하게될 수 있습니다.

하지만 시간 제한이 2초이기 때문에, 여유가 있다고 생각했습니다.

# 접근 과정

맵 전체를 `int[][]` 로 선언하고, 폭탄이 설치될 경우 해당 위치에는 폭탄이 터지는 시간인 `3`으로 초기화 해주었습니다.
그리고 `제한시간`까지, `설치` 또는 `폭발`을 반복해서 수행하는 방식으로 해답을 구했습니다.

# 삽질

답을 구하는데는 삽질이 없었습니다.
대신 풀이를 제출해보니, 시간 복잡도가 높게 나와서 줄이려고 시도해보며 삽질을 했었습니다.
그래도 삽질을 하며 `792ms` -> `168ms` 로 감소시키는데 성공하여 보람이 있었고,
코드에 병목이 되는 부분을 찾는 연습이 되어, 앞으로는 처음부터 병목이 되는 부분을 생각하며 코딩할 수 있을 것 같습니다.

## 1. 출력 로직에 `StringBuilder` 적용
`792ms`-> `368ms` = `424ms 감소`
생각없이 한줄씩 System.out.print 를 해줬었는데, 이게 가장 큰 병목이었던 것 같습니다..

## 2. 입력 받는 로직에 `Scanner` -> `BufferedReader` 적용
`368ms`-> `344ms` = `24ms 감소`
입력값을 정규식으로 필터링하여 입력받는 `Scanner` 대신, `BufferedReader` 로 대체하였습니다.
아주 큰 시간 감소는 아니었지만, 큰 입력값을 정규식 필터링을 하며 발생하는 오버헤드가 시간을 조금 더 소모했던 것 같습니다.

## 3. `String.toCharArray()` 대신 `String.charAt()` 를 활용
`344ms` -> `332ms` = `12ms 감소`
`toCharArray()` 가 `String` 내부의 `char[]` 을 복사하기 때문에 이 방법 대신에,
`String.length()` 만큼 반복하여 `String.charAt()` 으로 바로 `String` 내부의 `char[]` 에 랜덤엑세스 하는 방식이
더 효율적이지 않을까 생각했지만, 생각보다 큰 감소는 없었습니다.
```java
// 변경전
for (int y = 0; y < row; y++) {
    char[] rowChars = br.readLine().toCharArray();
    for (int x = 0; x < rowChars.length; x++) {
        if (rowChars[x] == CHR_BOMB)
        map[y][x] = BOMB_INIT_TIME;
    }
}

// 변경후
for (int y = 0; y < row; y++) {
    String line = br.readLine();
    for (int x = 0; x < line.length(); x++) {
        if (line.charAt(x) == CHR_BOMB)
        map[y][x] = BOMB_INIT_TIME;
    }
}
```

## 4. `installBomb` -> `installOrProcessBomb` 변경
`332ms` -> `288ms` = `44ms 감소`
변경전 로직에서는 1초에 전체 배열 탐색`O(N^2)` 작업이 2번 수행되었습니다.(installBomb, processBomb)
이를 하나로 합쳐서 1번만 수행되도록 변경하여 시간 복잡도를 줄였습니다.

```java
// 변경전
while(time < timeLimit) {
    time++;
    installBomb(map); // 4로 초기화
    processBomb(map); // 전체 숫자 -1 and 폭발작업
}

// 변경후
while(time < timeLimit) {
    time++;

    if (isInstallTurn) {
        installOrProcessBomb(map); // 3으로 초기화 or 전체 숫자 -1
    } else {
        processBomb(map); // 전체 숫자 -1 and 폭발작업
    }

    isInstallTurn = !isInstallTurn;
}
```

## 5. `processBomb` 각 좌표 queue 에 담아서 처리 -> 바로 처리
`288ms` -> `168ms` = `120ms 감소`
`processBomb` 라는 메소드는 배열을 돌며 1씩 감소시키고, 터져야할 폭탄이 있으면 터트리는 작업을 합니다.
한꺼번에 터져야 한다고 생각해서, 바로 배열에 값을 바꿔주지 않고, 터져야할 좌표를 Queue 에 저장한 뒤,
Queue 에 있는 좌표를 모두 꺼내서 폭발하게 했습니다.

Queue 에 저장하고 다시 꺼내서 반복하는 로직이 병목이 있을 것 같아서 바로 터트리는 작업을 하도록 수정하고,
동시에 터져야 하는 폭탄은 건드리지 않도록 변경하니 시간복잡도가 감소되었습니다.

```java
// 변경전
private static void processBomb(int[][] map) {
    Queue<Point> firePoints = new LinkedList<>();

    for (int y = 0; y < map.length; y++) {
        for (int x = 0; x < map[0].length; x++) {
            if (map[y][x] == EMPTY) continue;

            map[y][x]--;

            if (map[y][x] == EMPTY) {
                firePoints.add(new Point(x,y));
            }
        }
    }

    while(!firePoints.isEmpty()) {
        Point point = firePoints.poll();
        fireBomb(map, point.x, point.y);
    }
}

// 변경후
private static void processBomb(int[][] map) {
    for (int y = 0; y < map.length; y++) {
        for (int x = 0; x < map[0].length; x++) {
            if (map[y][x] == EMPTY) continue;

            map[y][x]--;

            if (map[y][x] == EMPTY) {
                fireBomb(map, x, y);
            }
        }
    }
}
```