### PR TITLE
[산토리] BOJ(1916): 최소비용 구하기 - 문제풀이

### DIFF
--- a/src/산토리/최소비용 구하기.py
+++ b/src/산토리/최소비용 구하기.py
@@ -1,0 +1,34 @@
+import sys, heapq
+from collections import defaultdict
+
+input = sys.stdin.readline
+
+N = int(input())
+M = int(input())
+
+# 단방향 그래프 작성
+graph = defaultdict(list)
+
+for _ in range(M):
+    u, v, w = list(map(int, input().split()))
+    graph[u].append((v, w))
+
+# 다익스트라 알고리즘의 출발점/도착점
+dep, dest = list(map(int, input().split()))
+
+# cost: 최소비용 저장 딕셔너리
+cost = defaultdict(int)
+
+# 우선순위 큐: [비용, 정점]
+heap = []
+heapq.heappush(heap, (0, dep))
+
+while heap:
+    cur_cost, cur_node = heapq.heappop(heap)
+    if cur_node not in cost:
+        cost[cur_node] = cur_cost
+        for adj_node, adj_cost in graph[cur_node]:
+            next_cost = cur_cost + adj_cost
+            heapq.heappush(heap, (next_cost, adj_node))
+
+print(cost[dest])


### PR DESCRIPTION
안녕하세요~ 산토리입니다.
화요일 문제 풀이 올립니다!

## 🐢 접근 과정
전형적인 다익스트라 알고리즘 문제로 보여 바로 다익스트라 구현에 집중했습니다.
오랜만에 써보는 알고리즘이라 구현하는 방향을 까먹어 삽질을 좀 했던 것 같습니다.
상길북의 psuedo code를 참고하여 우선순위 큐를 이용한 다익스트라 알고리즘으로 풀었습니다.  

1. 단방향 그래프 작성: 파이썬의 defaultdict 자료구조(HashMap과 유사)를 사용하여 작성하였습니다.

```python
graph = defaultdict(list)

for _ in range(M):
    u, v, w = list(map(int, input().split()))
    graph[u].append((v, w))
```

2. 최소 비용을 저장할 defaultdict와 우선순위 큐(최소 힙으로 구현) 생성한 다음 우선순위 큐에 시작점 push
```python
# cost: 최소비용 저장 딕셔너리
cost = defaultdict(int)

# 우선순위 큐: [비용, 정점]
heap = []
heapq.heappush(heap, (0, dep))
 ```

3. heap에 담긴 node를 순회하며 최소비용 업데이트가 되지 않은 node이면 업데이트
```python
while heap:
    cur_cost, cur_node = heapq.heappop(heap)
    if cur_node not in cost:
        cost[cur_node] = cur_cost
        for adj_node, adj_cost in graph[cur_node]:
            next_cost = cur_cost + adj_cost
            heapq.heappush(heap, (next_cost, adj_node))
```

이 부분에서 전통적인 방식과 좀 다른 방식으로 풀이해나갑니다. 최소비용(다익스트라에서 말하는 최단거리)을 저장한 딕셔너리에 해당 노드가 없을 때에만 업데이트를 진행하고 그 노드와 연결된 edge를 우선순위 큐에 담습니다. 이런식으로 한 번만 점검하면 cost에 저장된 값들은 모두 최소 비용이 됩니다.
왜냐하면 heap에서 꺼낼 때 항상 비용이 작은 노드부터 꺼내기 때문입니다. 
__즉, 임의의 노드가 힙에서 처음 빠져나온 시점이 가장 최소 비용(최단 거리)임이 보장됩니다.__
그러므로 처음 빠져나왔을 때 cost 딕셔너리에 값을 등록하고 그 이후부터는 해당 노드는 건너뛰게 됩니다.  
 
무난하게 푼다면 우선순위 큐를 활용한 BFS를 통해서 풀이하면 O(ElogV)로 풀이할 수 있을 것 같습니다.  

## 😡 삽질 과정
처음에 각 정점까지의 거리를 무한대로 세팅하는 전통적인 방식의 다익스트라를 하려고 했는데 이상하게 짜서 자꾸 시간초과가 났습니다..
그래서 우선순위 큐를 통한 거리를 업데이트하는 방식을 택하여 개선했습니다.

##  🕖 시간 복잡도
우선순위 큐(최소 힙)에 담긴 각 node에 연결된 모든 edge를 검사하므로 O(E*logE) 가 되겠습니다. (E: 간선의 개수)