### PR TITLE
[Miller] BOJ(1916): 최소비용 구하기 - 문제풀이

### DIFF
--- a/src/밀러/BOJ_1916.py
+++ b/src/밀러/BOJ_1916.py
@@ -1,0 +1,40 @@
+import collections
+import heapq
+from typing import List, Dict
+
+
+def solution(start: int, end: int, edges: List[List[int]]):
+
+    graph: Dict[int, List[List[int]]] = collections.defaultdict(list)
+
+    for edge in edges:
+        depart, arrive, cost = edge
+        graph[depart].append([arrive, cost])
+
+    dist: Dict[int, int] = collections.defaultdict(int)
+    queue: List[List[int]] = [[0, start]]
+
+    while queue:
+        total, now = heapq.heappop(queue)
+        if now in dist:
+            continue
+
+        dist[now] = total
+        for dest, cost in graph[now]:
+            alt: int = total + cost
+            heapq.heappush(queue, [alt, dest])
+
+    return dist[end]
+
+
+if __name__ == "__main__":
+    N: int = int(input())
+    M: int = int(input())
+    edges: List[List[int]] = []  # [depart, arrive, cost]
+
+    for _ in range(M):
+        edges.append(list(map(int, input().split())))
+
+    start, end = list(map(int, input().split()))
+
+    print(solution(start, end, edges))


### PR DESCRIPTION
안녕하세요, 최소비용 구하기 문제풀이를 들고온 밀러입니다 🧵

### 접근 과정

일단 먼저 DFS 로 풀었는데 시간복잡도가 발생했습니다.
그래프에서 간선의 가중치가 주어질 때 최소비용을 구하는 문제를 다익스트라 알고리즘으로 풀어야 한다고 알고 있었는데,
이전에 리트코드에서 풀었던 문제들은 DFS 로도 풀려서 이번에는 안되더라구요.

다익스트라 알고리즘에서 우선순위 큐를 이용했고,
큐 내부에서 최소힙으로 우선순위를 조정하면서 가중치의 합이 최소인 노드만 뽑아 해결할 수 있었습니다.

덕분에 항상 대충 DFS 로 풀었던 다익스트라 알고리즘을 풀 수 있어 좋았습니다.
아 그리고 백준에서 처음으로 골드 문제를 풀었네요! 감사합니다 땃쥐!