### PR TITLE
[Miller] PROGRAMMERS(72413): 합승 택시 요금 - 문제풀이

### DIFF
--- a/src/밀러/PROGRAMMERS_72413.py
+++ b/src/밀러/PROGRAMMERS_72413.py
@@ -1,0 +1,52 @@
+import collections
+import heapq
+import sys
+from typing import List, Dict
+
+
+def solution(n: int, s: int, a: int, b: int, fares: List[List[int]]):
+
+    graph: Dict[int, List[List[int]]] = collections.defaultdict(list)
+    dist: Dict[int, Dict[int]] = {}
+
+    for fare in fares:
+        start, end, cost = fare
+        graph[start].append([end, cost])
+        graph[end].append([start, cost])
+
+    def dijkstra(start: int):
+        queue = [[0, start]]
+        dist[start] = collections.defaultdict(lambda: None)
+
+        while queue:
+            cost, now = heapq.heappop(queue)
+            if now in dist[start]:
+                continue
+
+            dist[start][now] = cost
+            for dest, weight in graph[now]:
+                alt: int = cost + weight
+                heapq.heappush(queue, [alt, dest])
+
+    dijkstra(s)
+    dijkstra(a)
+    dijkstra(b)
+
+    answer: int = sys.maxsize
+    for node in range(1, n + 1):
+        if dist[s][node] is None or dist[a][node] is None or dist[b] is None:
+            continue
+
+        total: int = dist[s][node]
+        total += dist[a][node]
+        total += dist[b][node]
+
+        answer = min(answer, total)
+
+    return answer
+
+
+if __name__ == "__main__":
+    print(solution(6, 4, 6, 2, [[4, 1, 10], [3, 5, 24], [5, 6, 2], [3, 1, 41], [5, 1, 24], [4, 6, 50], [2, 4, 66], [2, 3, 22], [1, 6, 25]]))
+    print(solution(7, 3, 4, 1, [[5, 7, 9], [4, 6, 4], [3, 6, 1], [3, 2, 3], [2, 1, 6]]))
+    print(solution(6, 4, 5, 6, [[2, 6, 6], [6, 3, 7], [4, 6, 7], [6, 5, 11], [2, 5, 12], [5, 3, 20], [2, 4, 8], [4, 3, 9]]))


### PR DESCRIPTION
안녕하세요, 프로그래머스 합승 택시 요금 문제 풀이를 들고온 밀러입니다 🏃‍♂️
이번 문제 생각하기 쉽지 않았고, 처음 생각했던 풀이가 효율성에서 시간 초과가 발생해 시간을 많이 썼습니다 ㅠ

## 삽질 과정

먼저 제가 이 문제를 보고 생각한 전제는 다음과 같습니다.

> 출발지점 `s` 로부터 어떤 경유지 `m` 까지의 최소 요금을 계산하고, `m` 에서 도착지점 `a` 와 `b` 까지의 최소요금을 합해서 더하면 경유지 `m` 을 거칠 때 최소 요금이다.

그리고 위 전제로부터, 그래프 내의 모든 노드를 순회하면서 각 노드가 경유지일 때의 최소 요금을 계산하고,
그 중에서 가장 작은 값을 답으로 구하려고 했습니다.

그리고 아래와 같은 다익스트라 알고리즘을 적용한 함수를 모든 노드마다 3번씩 적용하고자 했습니다.
아래 함수를 실행하면, `start` 에서 `end` 까지 최소 요금을 구할 수 있습니다.

```python
dist: Dict[int, Dict[int]] = {}

def dijkstra(start: int, end: int):
    queue = [[0, start]]
    dist[start] = {}
    tmp: Dict[int, int] = {}

    while queue:
        cost, now = heapq.heappop(queue)
        if now in dist[start]:
            continue

        tmp[now] = cost
        for dest, weight in graph[now]:
            alt: int = cost + weight
            heapq.heappush(queue, [alt, dest])

    dist[start][end] = tmp[end]

for node in range(1, n + 1):
    dijkstra(s, node)
    dijkstra(node, a)
    dijkstra(node, b)
```

하지만 위와 같이 풀이할 경우 효율성 테스트를 통과하지 못합니다.

### 풀이 과정

위 풀이에서 시간 초과가 나는 이유가 각 노드마다 위 함수를 3번 실행하기 때문이라고 생각했습니다.
따라서, 시간을 줄이기 위해 저는 아래 2가지를 생각하게 되었습니다.

1. 양방향 그래프에서 출발지점 -> 도착지점과 도착지점 -> 출발지점 이동 시 드는 비용은 동일하다
2. 다익스트라 알고리즘을 활용한 위 함수를 실행하면 시작점으로부터 연결된 노드의 최소비용을 모두 구할 수 있다.

각 노드에서 도착지점 `a` 까지의 최소요금을 구하기 위해,
모든 노드를 순회하면서 각 노드에서 도착 지점 `a` 까지의 최소요금을 계산하기 위해 위 함수를 N번 실행했습니다.

하지만 1 과 2 를 종합해보면, 도착 지점 `s` 에서 출발해 각 노드까지의 최소 요금을 구하기 위해 함수를 1번만 실행하고,
`s` 에서 각 노드까지의 최소 요금을 딕셔너리에 저장하면 됩니다. 
마찬가지로 도착지점 `b` 에 대해서도 같은 원리를 적용할 수 있습니다.

따라서, 위 코드는 아래와 같이 변경할 수 있습니다.

```python
dist: Dict[int, Dict[int]] = {}

def dijkstra(start: int):
    queue = [[0, start]]
    dist[start] = {}

    while queue:
        cost, now = heapq.heappop(queue)
        if now in dist[start]:
            continue

        dist[start][now] = cost
        for dest, weight in graph[now]:
            alt: int = cost + weight
            heapq.heappush(queue, [alt, dest])

dijkstra(s)
dijkstra(a)
dijkstra(b)
```

이제 최소 요금을 구하기 위한 함수 실행 횟수가 N번에서 3번으로 줄었고,
출발지점 `s`-> 경유지와 경유지 -> 도착지점 `a`, `b` 까지의 각 최소 요금을 모두 구할 수 있습니다.
이제 경유지를 N번 순회하면서 어떤 경유지를 거쳤을 때 전체 요금이 최소가 도는지 구할 수 있습니다!

### 시간복잡도

우선순위 큐를 활용한 다익스트라 알고리즘을 활용하는데 간선이 최대 n(n-1) / 2 이므로
O(E log E) (E: 간선의 개수) = O(n^2 * log(n^2)) = O(n^3) 입니다.