### PR TITLE
[Miller] BOJ(11657): 타임머신 - 문제풀이

### DIFF
--- a/src/밀러/BOJ_11657.py
+++ b/src/밀러/BOJ_11657.py
@@ -1,0 +1,45 @@
+from typing import List
+
+INF: int = int(1e9)
+
+
+def solution(N: int, M:int, edges: List[List[int]]) -> List[int]:
+    dist: List[int] = [INF] * (N  + 1)
+
+    def bellman_ford(start: int):
+        dist[start] = 0
+
+        for turn in range(N):
+            for edge in edges:
+                now, dest, cost = edge
+
+                if dist[now] != INF and dist[dest] > dist[now] + cost:
+                    dist[dest] = dist[now] + cost
+
+                    if turn == N - 1:
+                        return False
+
+        return True
+
+    is_cycle: bool = bellman_ford(1)
+
+    if not is_cycle:
+        return [-1]
+
+    for ind in range(2, N + 1):
+        if dist[ind] == INF:
+            dist[ind] = -1
+
+    return dist[2:]
+
+
+if __name__ == "__main__":
+    N, M = list(map(int, input().split()))
+    edges: List[List[int]] = []
+
+    for _ in range(M):
+        edges.append(list(map(int, input().split())))
+
+    answer: List[int] = solution(N, M, edges)
+    for num in answer:
+        print(num)


### PR DESCRIPTION
안녕하세요, 백준 타임머신 문제 풀이를 들고온 밀러입니다 ✍
이번 문제는 제가 출제하기도 했고, 벨만-포드 알고리즘의 학습에 초점을 맞춰 해당 알고리즘을 공부하고 문제를 풀이해 별도의 삽질이 없었습니다.

### 풀이 과정

이전에 다룬 문제들에서는, 어떤 정점에서 모든 정점까지의 거리(혹은 비용)을 계산할 때 다익스트라 알고리즘을 사용했습니다.
하지만 이번 문제는 그래프에 음의 가중치를 갖는 간선이 있어 다익스트라 알고리즘을 사용할 경우, 음수인 간선의 가중치를 처리할 수 없습니다.

따라서, 음수인 값을 처리할 수 있는 벨만-포드 알고리즘으로 풀이해야합니다.

벨만-포드 알고리즘을 활용한 함수는 아래와 같습니다.

```python
def bellman_ford(start: int):
    dist[start] = 0

    for turn in range(N):
        for edge in edges:
            now, dest, cost = edge

            if dist[now] != INF and dist[dest] > dist[now] + cost:
                dist[dest] = dist[now] + cost

                if turn == N - 1:
                    return False

    return True
```

벨만-포드 알고리즘에서는 `V-1` 번 동안, 각 간선마다 edge relaxation 과정을 반복해야합니다. edge relaxation 에서는 출발 정점에서 간선의 종점까지 최소 비용보다 간선의 기점까지의 최소 비용 + 간선의 비용이 더 작을 경우 최소 비용을 갱신합니다.

그리고 `V - 1` 번 동안 반복한 후, 이후에도 최소 비용 갱신이 이루어지면 음의 값으로 인한 순환이 존재합니다.

### 시간 복잡도

V번동안 모든 간선을 순회하므로 O(VE) 입니다.