### PR TITLE
[Ader] BOJ(11657): 타임머신 - 문제풀이

### DIFF
--- a/src/아더/BOJ_11657_타임머신.java
+++ b/src/아더/BOJ_11657_타임머신.java
@@ -1,0 +1,88 @@
+package 아더;
+
+import java.io.*;
+import java.util.*;
+
+public class BOJ_11657_타임머신 {
+
+    static int N, M;
+    static boolean isCycle;
+    static long[] dist;
+    static List<Edge>[] edges;
+
+    static class Edge {
+        int to, weight;
+
+        public Edge(int to, int weight) {
+            this.to = to;
+            this.weight = weight;
+        }
+    }
+
+    public static void main(String[] args) {
+        try {
+            input();
+            solve();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private static void solve() {
+        Arrays.fill(dist, Integer.MAX_VALUE);
+
+        if (bellmanFord(1)) {
+            System.out.println(-1);
+        } else {
+            for (int i = 2; i <= N; i++) {
+                if (dist[i] == Integer.MAX_VALUE) {
+                    System.out.println(-1);
+                } else {
+                    System.out.println(dist[i]);
+                }
+            }
+        }
+    }
+
+    private static boolean bellmanFord(int start) {
+        dist[start] = 0;
+
+        for (int i = 0; i < N; i++) {
+            for (int j = 1; j <= N; j++) {
+                for (Edge edge : edges[j]) {
+                    if (dist[j] == Integer.MAX_VALUE) continue;
+                    if (dist[edge.to] > dist[j] + edge.weight) {
+                        dist[edge.to] = dist[j] + edge.weight;
+                        if (i == N - 1) {
+                            return true;
+                        }
+                    }
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static void input() throws IOException {
+        //BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedReader br = new BufferedReader(new FileReader(new File("C:\\Users\\k2j38\\OneDrive\\Desktop\\Park\\99.ETC\\input.txt")));
+
+        String[] split = br.readLine().split(" ");
+        N = Integer.parseInt(split[0]);
+        M = Integer.parseInt(split[1]);
+        isCycle = false;
+
+        dist = new long[N + 1];
+        edges = new List[N + 1];
+
+        for (int i = 1; i <= N; i++) {
+            edges[i] = new ArrayList<>();
+        }
+
+        for (int i = 0; i < M; i++) {
+            split = br.readLine().split(" ");
+            edges[Integer.parseInt(split[0])].add(new Edge(Integer.parseInt(split[1]), Integer.parseInt(split[2])));
+        }
+    }
+}


### PR DESCRIPTION
## 안녕하세요 아더입니다~!
이번주는 시간복잡도 특집이네요 ㅋㅋㅋㅋ
음수로 가중치가 주어지는 문제는 처음 접해봐서 `밀러`가 가이드해주신대로 `벨만포드 알고리즘`을 먼저 학습하고 문제를 풀어보았습니다. 좋은 알고리즘을 연습할 수 있게 문제를 출제해주신 `밀러` 감사합니다!

## 시간복잡도
벨만포드 알고리즘의 시간복잡도는 `O(VE)`라고 하네요.
다익스트라보다는 느립니다. 하지만 `음수간선의 순환을 감지`할 수 있다는 알고리즘이므로 꼭 알아둬야겠네요.

## 접근 과정
1. 출발노드를 설정합니다. 1번 점이 출발점이니 `dist[1] = 0`으로 초기화합니다.
2. dist[] 배열의 나머지를 `Arrays.fill(dist, Integer.MAX_VALUE)`로 초기화합니다. 이 과정에서 `dist 배열은 long 타입`으로 선언되어야 합니다.
3. 아래의 과정을 정점의 갯수만큼 반복합니다.
4. 전체 간선을 확인합니다. 최단거리가 있다면 갱신합니다.
5. `N-1`번째까지 갱신을 계속한다면 음수 사이클이 있다고 판단하고 true를 리턴하도록 합니다.

## 삽질 과정
1. 기존 다익스트라 풀이에서 사용하던 `우선순위 큐`를 계속 사용했는데 이것 때문에 예시 테스트케이스2에서 계속해서 무한루프가 발생했습니다.
2. 그래서 `우선순위 큐`를 빼버리고 그냥 모든 점의 모든 간선을 순회하며 계산했습니다.

## 이번 문제 해결도 고생많으셨습니다 여러분 👍