### PR TITLE
[산토리] BOJ(11657): 타임머신 - 문제풀이

### DIFF
--- a/src/산토리/타임머신.py
+++ b/src/산토리/타임머신.py
@@ -1,0 +1,34 @@
+import sys
+def get_answer():
+
+    N, M = list(map(int, input().split()))
+
+    dists = [sys.maxsize for _ in range(N+1)]
+    dists[1] = 0
+
+    graph = []
+    for _ in range(M):
+        a, b, c = list(map(int, input().split()))
+        graph.append((a,b,c))
+
+    answer = []
+    # 일단 시작점에서 각 점까지의 최단거리를 구한다
+    # 음의 가중치가 존재하므로 경로 상에 음의 가중치를 가지는 사이클이 발생하면 -1을 출력해야 한다
+    # 경로가 없는 경우에는 -1을 출력한다
+    for i in range(N):
+        for edge in graph:
+            a, b, c = edge
+            if dists[a] != sys.maxsize and dists[a] + c < dists[b]:
+                dists[b] = dists[a] + c
+                if i == N-1:
+                    print(-1)
+                    return
+
+    for dist in dists[2:]:
+        if dist == sys.maxsize:
+            print(-1)
+        else:
+            print(dist)
+
+
+get_answer()


### PR DESCRIPTION
안녕하세요.. 산토리입니다.
목요일 문제 풀이입니다..

## 😡 삽질 과정
일단 결과적으로 벨만-포드 알고리즘을 푸는 문제였는데 해당 알고리즘을 몰라서
어떻게 접근할지는 알겠는데 구현을 못하는 상황에서 집중력이 많이 떨어졌습니다.
결국 오래 붙잡긴 했지만 해당 알고리즘의 구현방식을 참고하여 구현했습니다.

여러가지 난관이 있었는데 `어떻게 가중치 합이 음수가 되는 사이클을 판별할 것인지?` 를 해결하지 못해서 답을 참고했던 것 같습니다.

## 🐢 접근 과정
처음에는 다익스트라 알고리즘을 응용해서 풀어보려고 했는데, 음의 사이클이 존재하는 경우 다익스트라 알고리즘을 돌리게 되면 while문이 폭발하게 됩니다. 

그래서 벨만-포드 알고리즘을 개념만 보고 구현해보려고 했는데, N개의 노드가 있을 때 모든 에지를 한번만 검사하면 최단거리가 나올 거라 생각했는데 생각해보니 아니었습니다. 

모든 에지를 한번 검사하면 순서에 따라 최대 (N-1)번을 검사해야 합니다. 1번 노드에서 어딘 가의 노드로 가기 위한 최단 경로의 최대 길이는 N-1이므로 N-1번동안 모든 에지를 검사해서 최단거리 업데이트를 진행해야 최단 거리임을 보장할 수 있습니다. 

극단적으로 1->2->3->4 와 같은 그래프가 있다면, 첫 번째 검사에 1->2 업데이트, 두 번째 검사에 2->3 업데이트, 세 번째 검사에 3->4 업데이트가 일어나기 때문입니다.

다익스트라 알고리즘에서는 이 과정을 가장 짧은 노드에 대해서만 하여 최적해를 구할 수 있었지만, 음의 가중치가 고려되면 무한 루프에 빠지게 되기 때문에 벨만-포드에서는 정석적인 방법으로 풀어야 하는 것입니다.  

결국 N-1번 루프를 돌리고, 마지막에 루프를 한 번 더돌려서 최단거리가 또 업데이트되는 노드가 존재한다면 그것은 음의 가중치를 갖는 사이클이 존재하여 계속 최단거리가 줄어든다는 것을 암시하므로 -1을 출력하도록 합니다. 

```python
for i in range(N):
        for edge in graph:
            a, b, c = edge
            if dists[a] != sys.maxsize and dists[a] + c < dists[b]:
                dists[b] = dists[a] + c
                if i == N-1:
                    print(-1)
                    return
```

##  🕖 시간 복잡도
O(N*M)입니다. N=노드의 개수, M=에지의 개수 