### PR TITLE
[Jay] BOJ(2056): 작업 - 문제풀이

### DIFF
--- a/src/제이/week6/BOJ_2056.java
+++ b/src/제이/week6/BOJ_2056.java
@@ -1,0 +1,117 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+import java.util.function.Consumer;
+
+import static java.lang.Integer.parseInt;
+
+public class BOJ_2056 {
+
+    private static int NO_RELATION = 0;
+    private static int STARTED = -1;
+
+    private static int taskCount;
+    private static int[] relations;
+    private static Task[] tasks;
+
+    public static void main(String[] args) throws Exception {
+        readInput();
+
+        List<Task> startedTask = new ArrayList<>();
+        List<Task> finishedTask = new ArrayList<>();
+
+        // 선행 관계가 없거나 완료된 Task 들을 시작할 목록에 추가
+        addStartableTask(startedTask);
+
+        int time = 0;
+
+        while(startedTask.size() > 0) {
+            time++;
+
+            for (Task currTask : startedTask) {
+                currTask.tick(); // Task 작업 수행 (시간 -1)
+
+                // 현재 Task 끝났으면, 이 Task 를 기다리는 Task 의 선행 관계 개수에 -1
+                if (currTask.isFinished()) {
+                    currTask.waitingTasks.forEach(Main::removeRelationOfWatingTask);
+                    finishedTask.add(currTask);
+                }
+            }
+
+            // 끝난 Task 들 목록에서 제거
+            startedTask.removeAll(finishedTask);
+            finishedTask.clear();
+
+            // 선행 조건이 없거나 완료된 Task 들을 시작할 목록에 추가
+            addStartableTask(startedTask);
+        }
+
+        System.out.println(time);
+    }
+
+    private static void removeRelationOfWatingTask(int index) {
+        relations[index]--;
+    }
+
+    private static void addStartableTask(List<Task> startedTask) {
+        for (int i = 1; i < relations.length; i++) {
+            if (relations[i] == NO_RELATION) {
+                startedTask.add(tasks[i]);
+                relations[i] = STARTED;
+            }
+        }
+    }
+
+    private static void readInput() throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        taskCount = parseInt(br.readLine());
+
+        relations = new int[taskCount+1];
+        tasks = new Task[taskCount+1];
+
+        for (int currIndex = 1; currIndex <= taskCount; currIndex++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            Task task = new Task();
+            task.index = currIndex;
+            task.time = parseInt(st.nextToken());
+
+            int relatedCount = parseInt(st.nextToken());
+            relations[currIndex] = relatedCount;
+
+            for (int j = 0; j < relatedCount; j++) {
+                int relatedIndex = parseInt(st.nextToken());
+                tasks[relatedIndex].waitingTasks.add(currIndex);
+            }
+
+            tasks[currIndex] = task;
+        }
+
+        // for (Task task : tasks) {
+        //     System.out.println(task);
+        // }
+    }
+}
+
+class Task {
+    int index;
+    int time;
+    Set<Integer> waitingTasks = new HashSet<>();
+
+    public void tick() {
+        time--;
+    }
+
+    public boolean isFinished() {
+        return time == 0;
+    }
+
+    @Override
+    public String toString() {
+        return "Task{" +
+                "index=" + index +
+                ", time=" + time +
+                ", waitingTasks=" + waitingTasks +
+                '}';
+    }
+}


### PR DESCRIPTION
# 시간 복잡도

시간 복잡도 계산이 어렵네요,,
O(N^2) 가 걸릴 것 같습니다.

# 접근 과정

![image](https://user-images.githubusercontent.com/45728407/162012820-4945fbcd-5c9f-4371-ab26-891ab4e055ed.png)

작업 문제는 위 그림 처럼 선행 작업이 완료되어야 해당 작업이 시작되며, 이 작업들은 병렬적으로 처리 가능한 문제 입니다.

문제를 풀기위해 먼저 `작업` 들에게 `번호(index)`, `소요시간(time)`, `내가 끝나기를 기다리는 작업의 번호(waitings)` 를 저장했습니다.
그리고 `작업의 선행 작업 개수(relations)`들을 저장하였는데요.

그러면 특정 작업이 끝났을 때, `waitings` 들의 `relations`를 하나씩 줄여나가며 만약 개수가 0이 된 작업이 있다면,
해당 작업을 시작 시키는 방식으로 동작하게 하게 하였습니다.

이렇게 하면 `작업의 동시성`과 `선행 작업 완료 여부를 확인`을 하며 작업들을 진행시킬 수 있습니다.

아래 핵심로직 및 주석을 첨부합니다.
```java
List<Task> startedTask = new ArrayList<>(); // 시작된 작업
List<Task> finishedTask = new ArrayList<>(); // 끝난 작업(startTask 에서 제거할 Task 들)

// 선행 관계가 없거나 완료된 Task(relations == 0) 들을 시작할 목록에 추가
addStartableTask(startedTask);

int time = 0;

while(startedTask.size() > 0) {
    time++;

    for (Task currTask : startedTask) {
        currTask.tick(); // Task 작업 수행 (시간 -1)

        // 현재 Task 끝났으면, 이 Task 가 끝나기를 기다리는 Task 의 선행 관계 개수를 -1
        if (currTask.isFinished()) {
            currTask.waitingTasks.forEach(Main::removeRelationOfWatingTask);
            finishedTask.add(currTask);
        }
    }

    // 끝난 Task 들 목록에서 제거
    startedTask.removeAll(finishedTask);
    finishedTask.clear();

    // 선행 조건이 없거나 완료된 Task 들을 시작할 목록에 추가
    addStartableTask(startedTask);
}

// ----------------------------------

class Task {
    int index;
    int time;
    Set<Integer> waitingTasks = new HashSet<>();

    public void tick() {
        time--;
    }

    public boolean isFinished() {
        return time == 0;
    }
}
```

# 삽질

처음에는 각 `Task` 가 `자신이 시작되려면 끝나야 하는 작업의 번호`를 저장했었는데, 이 방식으로 하니 너무 복잡해졌습니다.
그러다가 반대로 `내가 끝나기를 기다리는 작업의 번호` 를 저장하는 방식으로 바꾸니, 로직이 단순해져서 풀이할 수 있었습니다.