### PR TITLE
[산토리] BOJ(2110): 공유기 설치 - 문제풀이

### DIFF
--- a/src/산토리/공유기 설치.py
+++ b/src/산토리/공유기 설치.py
@@ -1,0 +1,49 @@
+import sys
+input = sys.stdin.readline
+# 최단 거리를 정해놓고 충족하는 지 검사한다.
+# 최단 거리를 정할 때 이분 탐색을 수행한다.
+# 최단 거리에 따라 정렬된 집 좌표를 하나씩 건너 뛰며 지정한 거리 미만이면 해당 집에 공유기를 설치하지 않았다고 판단한다.
+# 마지막까지 갔을 때 설치해야 하는 공유기 개수보다 적으면 거리가 큰 것이므로 범위를 줄여 다시 탐색한다.
+# 설치해야 하는 공유기 개수보다 많거나 같으면 거리가 작은 것이므로 거리의 벙뮈를 키워 다시 탐색한다.
+# 설치해야 하는 공유기 개수와 같은 경우에는 답을 기록해두고 마지막에 그 배열의 최댓값을 반환한다.
+
+N, C = list(map(int, input().split()))
+
+home = []
+
+for _ in range(N):
+    home.append(int(input()))
+
+home.sort()
+
+# print(home)
+
+left_home, right_home = home[0], home[-1]
+right = right_home - left_home
+left = 0
+result = []
+while left <= right:
+
+    mid = (left + right) // 2
+    dist = mid
+
+    cnt = 0
+    prev = 0
+    for idx, pos in enumerate(home):
+        if idx == 0:
+            cnt += 1
+            prev = pos
+            continue
+        if pos - prev >= mid: # 지정한 거리보다 길게 설치가 가능할 때
+            cnt += 1
+            prev = pos
+
+    if cnt < C:
+        right = mid - 1
+
+    else:
+        result.append(mid)
+        left = mid + 1
+
+# print(result)
+print(max(result))


### PR DESCRIPTION
안녕하세요! 산토리입니다.
목요일 문제 풀이 업로드합니다~

## 😡 삽질 과정
이분 탐색으로 풀어보면 될 것 같아서 이분탐색을 했는데 정답을 기록하는 조건을 헷갈렸습니다. 집을 순회하면서 정해진 거리 이상이면 무조건 공유기를 설치하도록 했습니다. 그래서 딱 정해진 개수에 맞게만 설치된 경우만 체크하려고 하면 실제로는 만족하는 경우가 있더라도 정답 후보에서 빠지게 됩니다. 정해진 개수보다 많은 경우에는 어느 집에서 공유기 몇개를 빼더라도 여전히 가장 짧은 거리는 동일할 것이므로 많은 경우도 포함해줘야 되는 것을 깨달았습니다. 

## 🐢 접근 과정
예전에 [비슷한 문제](https://programmers.co.kr/learn/courses/30/lessons/43236)를 푼 기억이 있어서 비슷한 방식으로 풀어봤습니다.
가장 인접한 집 사이의 거리를 임의로 정해놓고 이 거리를 만족하면서 공유기를 설치할 수 있는지를 검사합니다. 이 때 거리를 이분탐색하며 탐색을 진행합니다.

집을 위치순으로 정렬해놓고, 한 집에서 다음 집까지의 거리가 현재 만족해야 하는 거리보다 짧으면, 공유기를 설치하지 않고 넘어갑니다.  

그리고 만족해야 하는 거리보다 크거나 같으면, 공유기를 설치해도 되므로 공유기를 설치하고 cnt를 1개 늘립니다.

집을 모두 순회해서 공유기 개수가 C 이상이면, 해당 거리를 만족할 수 있는 경우이므로 정답 배열에 거리를 추가하고 이분 탐색의 범위를 큰쪽으로 늘립니다.

공유기 개수가 C보다 모자라면, 거리를 더 좁혀야 한다는 말이므로 이분 탐색의 범위를 작은쪽으로 늘립니다.

##  🕖 시간 복잡도
이분탐색에 소요되는 시간복잡도 O(logN) * 모든 집을 순회하는 시간복잡도 O(N) -> O(NlogN)