### PR TITLE
[땃쥐] BOJ(2056): 작업 - 문제풀이

### DIFF
--- a/src/땃쥐/BOJ_2056.java
+++ b/src/땃쥐/BOJ_2056.java
@@ -1,0 +1,80 @@
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.Queue;
+
+public class BOJ_2056 {
+
+    private static int N;
+    private static int[] costs; // 작업 비용들을 저장할 배열
+    private static int[] indegree; // 진입 차수(들어오는 간선의 갯수)
+    private static int[] results; // 각 작업을 순차적으로 작업했을 때 완료시점에서의 누적 시간
+    private static ArrayList<ArrayList<Integer>> nexts = new ArrayList<>();
+
+    public static void main(String[] args) throws IOException {
+        N = readInt();
+        costs = new int[N + 1];
+        indegree = new int[N + 1];
+        results = new int[N + 1];
+
+        for (int i = 0; i <= N; i++) {
+            nexts.add(new ArrayList<>());
+        }
+
+        for (int i = 1; i <= N; i++) {
+            costs[i] = readInt(); // 작업 비용
+            results[i] = costs[i];
+            indegree[i] = readInt(); // 진입 차수
+
+            for (int j = 0; j < indegree[i]; j++) {
+                int beforeNode = readInt(); // 현재 노드의 선행 노드
+                nexts.get(beforeNode).add(i); // 선행 노드의 다음 노드 list에 추가한다.
+            }
+        }
+
+        topologySort();
+
+        int totalCost = Integer.MIN_VALUE;
+        for (int i=1; i<=N; i++) {
+            totalCost = Math.max(totalCost, results[i]);
+        }
+        System.out.print(totalCost);
+    }
+
+    private static void topologySort() {
+        Queue<Integer> queue = new LinkedList<>();
+
+        for (int i=1; i<N; i++) {
+            if (indegree[i] == 0) {
+                queue.offer(i);
+            }
+        }
+
+        while (!queue.isEmpty()) {
+            int now = queue.poll(); // 큐에서 원소(노드) 꺼내기
+
+            // 해당 노드와 연결된 노드들의 진입차수에서 1 빼기
+            for (int next : nexts.get(now)) {
+                indegree[next]--;
+                results[next] = Math.max(results[next], results[now] + costs[next]); // 다음 노드 작업 완료 시간을 갱신
+                if (indegree[next] == 0) {
+                    queue.offer(next); // 진입차수가 0인 노드는 시간 누적계산이 완료된 노드임
+                }
+            }
+        }
+    }
+
+    private static int readInt() throws IOException {
+        int value = 0;
+
+        int input;
+        while (true) {
+            input = System.in.read();
+            if (input == ' ' || input == '\n') {
+                return value;
+            } else {
+                value = value * 10 + (input - 48);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 죄송합니닷!

문제를 늦게 제출했습니다... ㅜㅜ

---
## 시간복잡도
![image](https://user-images.githubusercontent.com/88282356/162619237-b7751fac-a9b8-4089-a02c-1d7e63be57d9.png)
(404ms)
- 노드의 갯수 N개를 전부 순회하고 E개의 간선들도 확인해야합니다.
- O(N+E)입니다.

---
## 풀이

### 변수
```java
    private static int N;
    private static int[] costs; // 작업 비용들을 저장할 배열
    private static int[] indegree; // 진입 차수(들어오는 간선의 갯수)
    private static int[] results; // 각 작업을 순차적으로 작업했을 때 완료시점에서의 누적 시간
    private static ArrayList<ArrayList<Integer>> nexts = new ArrayList<>();
```
- 작업의 갯수 N
- 각 작업별 비용을 정의한 costs
- `indegree[]` : 각 작업 기준 들어오는 간선의 갯수, 즉 선행작업의 갯수를 저장
- `results` : 최초 작업부터 최적시간으로 진행했을 때 해당 작업의 완료시점을 계산한 시점
- `nexts` : 각 인덱스 기준 다음에 오는 작업 번호들을 저장

### 초기화
```java
    public static void main(String[] args) throws IOException {
        N = readInt();
        costs = new int[N + 1];
        indegree = new int[N + 1];
        results = new int[N + 1];

        for (int i = 0; i <= N; i++) {
            nexts.add(new ArrayList<>());
        }

        for (int i = 1; i <= N; i++) {
            costs[i] = readInt(); // 작업 비용
            results[i] = costs[i];
            indegree[i] = readInt(); // 진입 차수

            for (int j = 0; j < indegree[i]; j++) {
                int beforeNode = readInt(); // 현재 노드의 선행 노드
                nexts.get(beforeNode).add(i); // 선행 노드의 다음 노드 list에 추가한다.
            }
        }
```
- 각 라인을 입력받을 때, 현재 노드의 선행노드들을 입력받게 된다.
- 선행노드 입장에서 현재 노드는 다음 노드이므로, 반대 입장에서 nexts에 저장한다.

### 로직
```java
        topologySort();

        int totalCost = Integer.MIN_VALUE;
        for (int i=1; i<=N; i++) {
            totalCost = Math.max(totalCost, results[i]);
        }
        System.out.print(totalCost);
```
- topologySort 메서드를 통해 results를 구한다. (이 메서드를 수행시 진입차수가 0인 작업부터 병행작업시 각 작업 종료 시점의 시간을 구할 수 있게 된다.)
-  results의 최댓값을 탐색한다. results의 최댓값이 전체 작업이 종료된 시점에서의 시간과 같다.

### topologySort()
```java
    private static void topologySort() {
        Queue<Integer> queue = new LinkedList<>();

        for (int i=1; i<N; i++) {
            if (indegree[i] == 0) {
                queue.offer(i);
            }
        }

        while (!queue.isEmpty()) {
            int now = queue.poll(); // 큐에서 원소(노드) 꺼내기

            // 해당 노드와 연결된 노드들의 진입차수에서 1 빼기
            for (int next : nexts.get(now)) {
                indegree[next]--;
                results[next] = Math.max(results[next], results[now] + costs[next]); // 다음 노드 작업 완료 시간을 갱신
                if (indegree[next] == 0) {
                    queue.offer(next); // 진입차수가 0인 노드는 시간 누적계산이 완료된 노드임
                }
            }
        }
    }
```
- 배열을 순회하여 진입차수가 0인 노드를 탐색하고 queue에 넣는다.
- queue가 빌 때까지 반복한다.
  - queue에서 작업을 꺼낸다.
  - 작업 기준으로 nexts에 위치한 다음 노드들을 순회하여 results를 갱신한다.
    - next를 꺼내면, 일단 next 입장에서 계산해야할 진입차수값을 1 감소시킨다.
    - 다음 작업 종료시점의 누적시간값은 results에 저장되어 있는 값 / 현재 작업 종료시점의 누적시간 + 비용  양쪽을 비교했을 때 최댓값으로 갱신한다. 왜 이런 것이 되나면, 다음 작업 입장에선 다른 선행작업들이 있기 마련인데 해당 작업들도 종료되어야 다음 작업이 진행되기 때문이다. 한 작업에 진입하기 위해 필요한 여러 작업들이 모두 종료되어야 진입가능하기 때문이다.
    - 진입차수가 0이 되버린 next노드는 계산이 완료된 노드이므로 queue에 삽입한다.

---