### PR TITLE
[산토리] BOJ(1197): 최소 스패닝 트리

### DIFF
--- a/src/산토리/최소 스패닝 트리.py
+++ b/src/산토리/최소 스패닝 트리.py
@@ -1,0 +1,29 @@
+import heapq
+from collections import defaultdict
+V, E = list(map(int, input().split()))
+
+graph = defaultdict(list)
+edges = []
+
+for _ in range(E):
+    a, b, c = list(map(int, input().split()))
+    graph[a].append((b,c))
+    graph[b].append((a,c))
+
+# heapq.heapify(edges)
+visited = [False for _ in range(V+1)]
+answer = 0
+
+cnt = 0
+heap = [(0, 1)]
+while cnt < V:
+    cost, v = heapq.heappop(heap)
+    if not visited[v]:
+        answer += cost
+        visited[v] = True
+        cnt += 1
+        for w, cost in graph[v]:
+            heapq.heappush(heap, (cost, w))
+            
+
+print(answer)


### PR DESCRIPTION
안녕하세요~ 산토리입니다!

## 삽질 과정
처음에 각 간선의 양 끝점에 있는 정점을 다 방문처리해줘야 되는 줄 알았는데 그냥 한 정점에서 시작하여 탐색하듯이 도착점을 방문처리 해주면 되는 것이었습니다;;

## 접근 과정
가중치 합이 최소가 되려면 각 정점에서 가중치가 가장 작은 간선을 선택하면 됩니다. 각 간선을 heap으로 구성한다음 가중치가 최소인 간선을 선택해서 반영해줍니다. 선택된 간선에 해당하는 정점은 방문처리를 한다음, 모두 방문할때까지 반복합니다.

## 시간 복잡도
간선의 개수가 N일 때, 모든 간선에 대해 힙정렬을 수행한 것이므로 O(NlogN)입니다.  