### PR TITLE
[Miller] BOJ(1197): 최소 스패닝 트리 - 문제풀이

### DIFF
--- a/src/밀러/BOJ_1197.py
+++ b/src/밀러/BOJ_1197.py
@@ -1,0 +1,44 @@
+from typing import List, Tuple
+
+
+def find_parent(parent, x):
+    if parent[x] != x:
+        parent[x] = find_parent(parent, parent[x])
+    return parent[x]
+
+
+def union_parent(parent, a, b):
+    a: int = find_parent(parent, a)
+    b: int = find_parent(parent, b)
+    if a < b:
+        parent[b] = a
+    else:
+        parent[a] = b
+
+
+def solution(V: int, edges: List[Tuple[int, int, int]]):
+    parent: List[int] = [0] * (V + 1)
+    for ind in range(1, V + 1):
+        parent[ind] = ind
+
+    edges.sort()
+
+    result: int = 0
+    for edge in edges:
+        cost, a, b = edge
+        if find_parent(parent, a) != find_parent(parent, b):
+            union_parent(parent, a, b)
+            result += cost
+
+    return result
+
+
+if __name__ == "__main__":
+    V, E = map(int, input().split())
+    edges: List[Tuple[int, int, int]] = []
+
+    for _ in range(E):
+        a, b, cost = map(int, input().split())
+        edges.append((cost, a, b))
+
+    print(solution(V, edges))


### PR DESCRIPTION
문제풀이를 늦게 올려서 죄송합니다 😭

### 문제풀이

최소 스패닝 트리 문제를 크루스칼 알고리즘으로 풀이했습니다.
문제풀이 과정에서 Union-Find 알고리즘을 사용했습니다.

- `Union` : 부모가 다른 2개의 노드를 같은 부모를 가지는 하나의 트리로 합칠 때 사용 
- `Find` : 두 노드의 부모가 다른지 확인할 때 사용

비용 별로 오름차순 정렬된 간선에 대해 사이클이 존재하는지 확인하기 위해 `Find` 함수를 호출하며,
사이클이 존재하지 않는 경우에는 `Union` 함수를 호출해 최소 스패닝 트리에 간선을 추가합니다.

### 시간 복잡도

간선을 비용 별로 오름차순 정렬하는데 O(ElogE) 의 시간복잡도를 가집니다.
그 외에는 간선 별로 1번만 순회하기 때문에 최대 시간복잡도는 O(ElogE) 입니다.
