### PR TITLE
[Miller] BOJ(1932): 정수 삼각형 - 문제풀이

### DIFF
--- a/src/밀러/BOJ_1932.py
+++ b/src/밀러/BOJ_1932.py
@@ -1,0 +1,23 @@
+from typing import List
+
+
+def solution(nums: List[List[int]]) -> int:
+    dp: List[List[int]] = [[0] * len(nums)] * len(nums)
+
+    for r in reversed(range(len(nums))):
+        for c in range(r + 1):
+            if r == len(nums) - 1:
+                dp[r][c] = nums[r][c]
+            else:
+                dp[r][c] = nums[r][c] + max(dp[r + 1][c], dp[r][c + 1])
+
+    return dp[0][0]
+
+
+if __name__ == "__main__":
+    n: int = int(input())
+    nums: List[List[int]] = []
+
+    for _ in range(n):
+        nums.append(list(map(int, input().split())))
+    print(solution(nums))

--- a/src/밀러/BOJ_1932.py
+++ b/src/밀러/BOJ_1932.py
@@ -9,7 +9,7 @@ def solution(nums: List[List[int]]) -> int:
             if r == len(nums) - 1:
                 dp[r][c] = nums[r][c]
             else:
-                dp[r][c] = nums[r][c] + max(dp[r + 1][c], dp[r][c + 1])
+                dp[r][c] = nums[r][c] + max(dp[r + 1][c], dp[r + 1][c + 1])
 
     return dp[0][0]
 


### PR DESCRIPTION
안녕하세요, 백준 정수 삼각형 문제풀이를 들고온 Miller 입니다!
늦게 제출하게 되어 죄송합니다 ㅠ

### 시간복잡도

DP 를 사용하고 정수 삼각형의 크기에 따라 순회하는 횟수가 달라지므로 O(n^2) 입니다.

### 풀이 방법

DP 를 활용하면서, 점화식을 더 쉽게 만들 수 있는 방법을 생각하기 위해
정수삼각형을 뒤집어서 맨 아래에서부터 맨 위로 합을 더하면서 올라가는 방법을 생각했습니다.

```python
if r == len(nums) - 1:
    dp[r][c] = nums[r][c]
else:
    dp[r][c] = nums[r][c] + max(dp[r + 1][c], dp[r + 1][c + 1])
```

맨 아래 줄은 정수 삼각형의 숫자값을 그대로 DP 배열에 저장하고,
그 윗줄부터는 정수 삼각형의 숫자값과 아래의 숫자 중 큰 값을 합해 DP 배열에 저장합니다.

### 삽질

배열의 인덱스가 하나 틀렸었는데 백준에서 맞았더라구요...?
이런 경우도 있네요 ㅋㅋ
