### PR TITLE
[Miller] BOJ(11049): 행렬 곱셈 순서 - 문제풀이 추가

### DIFF
--- a/src/밀러/BOJ_11049.py
+++ b/src/밀러/BOJ_11049.py
@@ -1,0 +1,45 @@
+import sys
+from typing import List, Tuple, Optional
+
+
+def solution_fail(n: int, matrices: List[List[int]]) -> int:
+    dp: List[List[int]] = [[0 for y in range(n)] for x in range(n)]
+
+    for i in range(1, n + 1):
+        for j in range(n - i):
+            r, c = j, j + i
+
+            left: int = dp[r][c - 1] + matrices[r][0] * matrices[c][0] * matrices[c][1]
+            right: int = matrices[r][0] * matrices[r][1] * matrices[c][1] + dp[r + 1][c]
+
+            dp[r][c] = min(left, right)
+
+    return dp[0][n - 1]
+
+
+def solution_success(n: int, matrices: List[List[int]]) -> int:
+    dp: List[List[int]] = [[0 for y in range(n)] for x in range(n)]
+
+    for i in range(1, n + 1):
+        for j in range(n - i):
+            r, c = j, j + i
+
+            if i == 1:
+                dp[r][c] = matrices[r][0] * matrices[r][1] * matrices[c][1]
+                continue
+
+            dp[r][c] = sys.maxsize
+            for k in range(r, c):
+                dp[r][c] = min(dp[r][c], dp[r][k] + dp[k + 1][c]
+                               + matrices[r][0] * matrices[k][1] * matrices[c][1])
+
+    return dp[0][n - 1]
+
+
+if __name__ == "__main__":
+    N: int = int(input())
+    arr: List[List[int]] = []
+
+    for _ in range(N):
+        arr.append(list(map(int, input().split())))
+    print(solution_success(N, arr))


### PR DESCRIPTION
너무 늦게 제출해서 죄송합니다 ㅠㅠ
문제를 푼 건 목요일 쯤이었는데.. 이제야 올립니다.

### 문제 풀이 방법

최근에 골드 3~4 문제를 주로 풀면서 DP 문제를 자주 마주쳤는데, 이번 문제 역시 DP 였습니다.

일단 이 문제를 풀이하는 것은 실패했습니다.
주어진 테스트 케이스를 몇 개 넣어봤을 때 통과했는데, 풀이를 제출하면 결국 틀리더라구요.
문제가 되는 테스트 케이스는 아래와 같았습니다.

```text
8
1 100
100 1
1 100
100 1
1 100
100 1
1 100
100 1
```

예를 들면, ABCDE 를 곱한다고 했을 때
제 풀이는 A * BCDE 와 ABCD * E 중 행렬 곱셈의 최솟값을 구하지만,
정답 풀이는 A * BCDE, AB * CDE, ABC * DE, ABCD * E 중 행렬 곱셈의 최솟값을 구합니다.

정답의 풀이와 DP 배열 내 상태 공간 정의나 DP 내 반복 등이 거의 비슷했지만,
점화식에서 놓쳐 아쉬운 문제였습니다.
일단 테스트 케이스를 맞추는 것을 목표로 하기보다, 더 일반적인 해법을 생각해보면서 풀이해야겠습니다.